### PR TITLE
feat: add support for 2.5 pro advanced model

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Currently available models (as of Feb 5, 2025):
 
 Models pending update (may not work as expected):
 
+- `gemini-2.5-exp-advanced` - Gemini 2.5 Experimental Advanced **(requires Gemini Advanced account)**
 - `gemini-2.0-exp-advanced` - Gemini 2.0 Experimental Advanced **(requires Gemini Advanced account)**
 - `gemini-1.5-pro` - Gemini 1.5 Pro **(requires Gemini Advanced account)**
 - `gemini-1.5-pro-research` - Gemini 1.5 Pro with Deep Research **(requires Gemini Advanced account)**

--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -50,6 +50,11 @@ class Model(Enum):
         {"x-goog-ext-525001261-jspb": '[null,null,null,null,"b1e46a6037e6aa9f"]'},
         True,
     )
+    G_2_5_EXP_ADVANCED = (
+        "gemini-2.5-exp-advanced",
+        {"x-goog-ext-525001261-jspb": '[null,null,null,null,"203e6bb81620bcfe"]'},
+        True,
+    )
     G_1_5_FLASH = (
         "gemini-1.5-flash",
         {"x-goog-ext-525001261-jspb": '[null,null,null,null,"418ab5ea040b5c43"]'},


### PR DESCRIPTION
- Previous `gemini-2.0-exp-advanced` might be deprecated.
- Add support for `gemini-2.5-exp-advanced`, details [here](https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/).