### PR TITLE
Fix HTML Entity Encoding Issue

### DIFF
--- a/src/gemini_webapi/types/candidate.py
+++ b/src/gemini_webapi/types/candidate.py
@@ -1,3 +1,4 @@
+import html
 from pydantic import BaseModel
 
 from .image import Image, WebImage, GeneratedImage
@@ -26,6 +27,14 @@ class Candidate(BaseModel):
     thoughts: str | None = None
     web_images: list[WebImage] = []
     generated_images: list[GeneratedImage] = []
+
+    def __init__(self, **data):
+        # HTML unescape text and thoughts if they exist
+        if "text" in data and data["text"]:
+            data["text"] = html.unescape(data["text"])
+        if "thoughts" in data and data["thoughts"]:
+            data["thoughts"] = html.unescape(data["thoughts"])
+        super().__init__(**data)
 
     def __str__(self):
         return self.text

--- a/tests/test_html_entity_decode.py
+++ b/tests/test_html_entity_decode.py
@@ -5,46 +5,44 @@ from gemini_webapi.types.candidate import Candidate
 class TestHtmlEntityDecode(unittest.TestCase):
     def test_html_entity_decoding(self):
         # Test HTML entity decoding functionality
-        html_encoded_text = "This is a code snippet: &lt;code&gt;print('Hello, World!')&lt;/code&gt;"
-        expected_decoded_text = "This is a code snippet: <code>print('Hello, World!')</code>"
-        
+        html_encoded_text = (
+            "This is a code snippet: &lt;code&gt;print('Hello, World!')&lt;/code&gt;"
+        )
+        expected_decoded_text = (
+            "This is a code snippet: <code>print('Hello, World!')</code>"
+        )
+
         # Create Candidate instance which should automatically decode HTML entities
         candidate = Candidate(
             rcid="test_rcid",
             text=html_encoded_text,
-            thoughts="Testing &lt;b&gt;HTML&lt;/b&gt; entity decoding"
+            thoughts="Testing &lt;b&gt;HTML&lt;/b&gt; entity decoding",
         )
-        
+
         # Verify that text property is correctly decoded
         self.assertEqual(candidate.text, expected_decoded_text)
-        
+
         # Verify that thoughts property is correctly decoded
         self.assertEqual(candidate.thoughts, "Testing <b>HTML</b> entity decoding")
-        
+
     def test_non_html_text(self):
         # Test plain text without any HTML entities
         plain_text = "This is regular text with no HTML entities"
-        
-        candidate = Candidate(
-            rcid="test_rcid",
-            text=plain_text
-        )
-        
+
+        candidate = Candidate(rcid="test_rcid", text=plain_text)
+
         # Verify the text remains unchanged
         self.assertEqual(candidate.text, plain_text)
-        
+
     def test_complex_html_entities(self):
         # Test more complex combinations of HTML entities
         complex_html = "&lt;div&gt;This has &amp;amp; character\n and &quot;quotes&quot;&lt;/div&gt;"
-        expected_decoded = "<div>This has &amp; character\n and \"quotes\"</div>"
-        
-        candidate = Candidate(
-            rcid="test_rcid",
-            text=complex_html
-        )
-        
+        expected_decoded = '<div>This has &amp; character\n and "quotes"</div>'
+
+        candidate = Candidate(rcid="test_rcid", text=complex_html)
+
         self.assertEqual(candidate.text, expected_decoded)
 
 
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()

--- a/tests/test_html_entity_decode.py
+++ b/tests/test_html_entity_decode.py
@@ -1,0 +1,50 @@
+import unittest
+from gemini_webapi.types.candidate import Candidate
+
+
+class TestHtmlEntityDecode(unittest.TestCase):
+    def test_html_entity_decoding(self):
+        # Test HTML entity decoding functionality
+        html_encoded_text = "This is a code snippet: &lt;code&gt;print('Hello, World!')&lt;/code&gt;"
+        expected_decoded_text = "This is a code snippet: <code>print('Hello, World!')</code>"
+        
+        # Create Candidate instance which should automatically decode HTML entities
+        candidate = Candidate(
+            rcid="test_rcid",
+            text=html_encoded_text,
+            thoughts="Testing &lt;b&gt;HTML&lt;/b&gt; entity decoding"
+        )
+        
+        # Verify that text property is correctly decoded
+        self.assertEqual(candidate.text, expected_decoded_text)
+        
+        # Verify that thoughts property is correctly decoded
+        self.assertEqual(candidate.thoughts, "Testing <b>HTML</b> entity decoding")
+        
+    def test_non_html_text(self):
+        # Test plain text without any HTML entities
+        plain_text = "This is regular text with no HTML entities"
+        
+        candidate = Candidate(
+            rcid="test_rcid",
+            text=plain_text
+        )
+        
+        # Verify the text remains unchanged
+        self.assertEqual(candidate.text, plain_text)
+        
+    def test_complex_html_entities(self):
+        # Test more complex combinations of HTML entities
+        complex_html = "&lt;div&gt;This has &amp;amp; character\n and &quot;quotes&quot;&lt;/div&gt;"
+        expected_decoded = "<div>This has &amp; character\n and \"quotes\"</div>"
+        
+        candidate = Candidate(
+            rcid="test_rcid",
+            text=complex_html
+        )
+        
+        self.assertEqual(candidate.text, expected_decoded)
+
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
Thank you for your work!

This PR addresses the issue of HTML entities not being decoded in the Gemini Web API responses. In responses from Gemini Web, code tags such as `<code>print("Hello World")</code>` are encoded as `&lt;code>print("Hello World")&lt;/code>`.

Changes Made

- Added an `__init__` method to the Candidate class, using html.unescape to automatically decode HTML entities in the response text during initialization.

- Applied this decoding to both the text and thoughts attributes to ensure the correct, unencoded text is displayed.