### PR TITLE
feat: add support for premium Gemini models and fix existing headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ Currently available models (as of November 20, 2025):
 - `gemini-3.0-pro` - Gemini 3.0 Pro
 - `gemini-2.5-pro` - Gemini 2.5 Pro
 - `gemini-2.5-flash` - Gemini 2.5 Flash
+- `gemini-3.0-pro-premium` - Gemini 3.0 Pro Premium (requires advanced access)
+- `gemini-2.5-flash-premium` - Gemini 2.5 Flash Premium (requires advanced access)
+- `gemini-2.5-pro-premium` - Gemini 2.5 Pro Premium (requires advanced access)
+
+> [!NOTE]
+>
+> Premium models (marked with "Premium") require a Google Gemini Advanced subscription. Using these models without proper access may result in errors.
 
 ```python
 from gemini_webapi.constants import Model

--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -50,13 +50,29 @@ class Model(Enum):
     )
     G_2_5_FLASH = (
         "gemini-2.5-flash",
-        {"x-goog-ext-525001261-jspb": '[1,null,null,null,"9ec249fc9ad08861",null,null,0,[4]]'},
+        {"x-goog-ext-525001261-jspb": '[1,null,null,null,"9ec249fc9ad08861",null,null,null,[4]]'},
         False,
     )
     G_2_5_PRO = (
         "gemini-2.5-pro",
-        {"x-goog-ext-525001261-jspb": '[1,null,null,null,"4af6c7f5da75d65d",null,null,0,[4]]'},
+        {"x-goog-ext-525001261-jspb": '[1,null,null,null,"4af6c7f5da75d65d",null,null,null,[4]]'},
         False,
+    )
+
+    G_3_0_PRO_PREMIUM = (
+        "gemini-3.0-pro-premium",
+        {"x-goog-ext-525001261-jspb": '[1,null,null,null,"e6fa609c3fa255c0",null,null,null,[4]]'},
+        True,
+    )
+    G_2_5_FLASH_PREMIUM = (
+        "gemini-2.5-flash-premium",
+        {"x-goog-ext-525001261-jspb": '[1,null,null,null,"71c2d248d3b102ff",null,null,null,[4]]'},
+        True,
+    )
+    G_2_5_PRO_PREMIUM = (
+        "gemini-2.5-pro-premium",
+        {"x-goog-ext-525001261-jspb": '[1,null,null,null,"4af6c7f5da75d65d",null,null,null,[4]]'},
+        True,
     )
 
     def __init__(self, name, header, advanced_only):


### PR DESCRIPTION
- Add three new premium models:
  * gemini-3.0-pro-premium
  * gemini-2.5-flash-premium
  * gemini-2.5-pro-premium
- Fix JSPB header parameters for existing 2.5 models
- Update README with premium model documentation and access requirements
- All premium models require Google Gemini Advanced subscription

BREAKING CHANGE: Premium models require advanced access and may fail without proper subscription