### PR TITLE
feat: add no-thinking variants for Gemini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Currently available models (as of November 20, 2025):
 - `gemini-3.0-pro` - Gemini 3.0 Pro
 - `gemini-2.5-pro` - Gemini 2.5 Pro
 - `gemini-2.5-flash` - Gemini 2.5 Flash
+- `gemini-3.0-pro-nothinking` - Gemini 3.0 Pro (No Thinking)
+- `gemini-2.5-pro-nothinking` - Gemini 2.5 Pro (No Thinking)
+- `gemini-2.5-flash-nothinking` - Gemini 2.5 Flash (No Thinking)
 
 ```python
 from gemini_webapi.constants import Model

--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -64,6 +64,27 @@ class Model(Enum):
         },
         False,
     )
+    G_3_0_PRO_NOTHINKING = (
+        "gemini-3.0-pro-nothinking",
+        {
+            "x-goog-ext-525001261-jspb": '[1,null,null,null,"9d8ca3786ebdfbea",null,null,null,[4]]'
+        },
+        False,
+    )
+    G_2_5_PRO_NOTHINKING = (
+        "gemini-2.5-pro-nothinking",
+        {
+            "x-goog-ext-525001261-jspb": '[1,null,null,null,"4af6c7f5da75d65d",null,null,null,[4]]'
+        },
+        False,
+    )
+    G_2_5_FLASH_NOTHINKING = (
+        "gemini-2.5-flash-nothinking",
+        {
+            "x-goog-ext-525001261-jspb": '[1,null,null,null,"9ec249fc9ad08861",null,null,null,[4]]'
+        },
+        False,
+    )
 
     def __init__(self, name, header, advanced_only):
         self.model_name = name


### PR DESCRIPTION
- Add gemini-3.0-pro-nothinking model with specialized header
- Add gemini-2.5-pro-nothinking model with specialized header
- Add gemini-2.5-flash-nothinking model with specialized header
- Update README.md with new model documentation

These variants provide optimized performance by disabling the thinking process while maintaining the same model capabilities.

https://github.com/HanaokaYuzu/Gemini-API/pull/161#issuecomment-3561090081