### PR TITLE
add client.delete_chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A reverse-engineered asynchronous python wrapper for [Google Gemini](https://gem
   - [Generate contents with files](#generate-contents-with-files)
   - [Conversations across multiple turns](#conversations-across-multiple-turns)
   - [Continue previous conversations](#continue-previous-conversations)
+  - [Delete previous conversations from Gemini history](#delete-previous-conversations-from-gemini-history)
   - [Streaming mode](#streaming-mode)
   - [Select language model](#select-language-model)
   - [Apply system prompt with Gemini Gems](#apply-system-prompt-with-gemini-gems)
@@ -215,6 +216,23 @@ async def main():
     previous_chat = client.start_chat(metadata=previous_session)
     response = await previous_chat.send_message("What was my previous message?")
     print(response)
+
+asyncio.run(main())
+```
+
+### Delete previous conversations from Gemini history
+
+You can delete a specific chat from Gemini history on the server by calling `GeminiClient.delete_chat` with the chat id.
+
+```python
+async def main():
+    # Start a new chat session
+    chat = client.start_chat()
+    await chat.send_message("This is a temporary conversation.")
+
+    # Delete the chat
+    await client.delete_chat(chat.cid)
+    print(f"Chat deleted: {chat.cid}")
 
 asyncio.run(main())
 ```

--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -832,6 +832,25 @@ class GeminiClient(GemMixin):
 
         return ChatSession(geminiclient=self, **kwargs)
 
+    async def delete_chat(self, cid: str) -> None:
+        """
+        Delete a specific conversation by chat id.
+
+        Parameters
+        ----------
+        cid: `str`
+            The ID of the chat requiring deletion (e.g. "c_...").
+        """
+
+        await self._batch_execute(
+            [
+                RPCData(
+                    rpcid=GRPC.DELETE_CHAT,
+                    payload=json.dumps([cid]),
+                ),
+            ]
+        )
+
     @running(retry=2)
     async def _batch_execute(self, payloads: list[RPCData], **kwargs) -> Response:
         """
@@ -893,56 +912,6 @@ class GeminiClient(GemMixin):
             self.cookies.update(self.client.cookies)
 
         return response
-
-    async def delete_chat(self, cid: str) -> bool:
-        """
-        Delete a specific chat conversation.
-
-        Parameters
-        ----------
-        cid: `str`
-            The ID of the chat requiring deletion (e.g. "c_...").
-
-        Returns
-        -------
-        `bool`
-            True if deletion was successful.
-
-        Raises
-        ------
-        `gemini_webapi.APIError`
-            If the batch execution fails.
-        """
-
-        await self._batch_execute(
-            [
-                RPCData(
-                    rpcid=GRPC.DELETE_CHAT1,
-                    payload=json.dumps([cid]),
-                ),
-            ]
-        )
-
-        await self._batch_execute(
-            [
-                RPCData(
-                    rpcid=GRPC.DELETE_CHAT2,
-                    payload=json.dumps([cid, [1, None, 0, 1]]),
-                ),
-            ]
-        )
-
-        await self._batch_execute(
-            [
-                RPCData(
-                    rpcid=GRPC.DELETE_CHAT3,
-                    payload=json.dumps([["bard_activity_enabled"]]),
-                ),
-            ]
-        )
-        # We assume success if status_code is 200 (checked in _batch_execute)
-        # Detailed success check could parse the inner response, but typically 200 is sufficient.
-        return True
 
 
 class ChatSession:

--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -18,6 +18,7 @@ class GRPC(StrEnum):
     # Chat methods
     LIST_CHATS = "MaZiqc"
     READ_CHAT = "hNvQHb"
+    DELETE_CHAT = "GzXR5e"
 
     # Gem methods
     LIST_GEMS = "CNgdBe"
@@ -27,12 +28,6 @@ class GRPC(StrEnum):
 
     # Activity methods
     BARD_ACTIVITY = "ESY5D"
-
-
-    # Delete methods
-    DELETE_CHAT1 = "GzXR5e"
-    DELETE_CHAT2 = "qWymEb"
-    DELETE_CHAT3 = "ESY5D"
 
 
 class Headers(Enum):

--- a/tests/test_client_features.py
+++ b/tests/test_client_features.py
@@ -154,6 +154,14 @@ class TestGeminiClient(unittest.IsolatedAsyncioTestCase):
         logger.debug(response2.images)
 
     @logger.catch(reraise=True)
+    async def test_delete_chat(self):
+        chat = self.geminiclient.start_chat()
+        await chat.send_message("This is a temporary conversation.")
+        self.assertIsNotNone(chat.cid)
+        await self.geminiclient.delete_chat(chat.cid)
+        logger.debug(f"Chat deleted: {chat.cid}")
+
+    @logger.catch(reraise=True)
     async def test_card_content(self):
         response = await self.geminiclient.generate_content("How is today's weather?")
         logger.debug(response.text)


### PR DESCRIPTION
Here is a change that enables cllient.delete_chat(cid)

Some usage:


```
response = await client.generate_content("What is the capital of Arizona?")

# helper: extract cid from metadata if available
# metadata is [cid, rid, rcid]
if response.metadata and len(response.metadata) > 0 and response.metadata[0]:
        cid = response.metadata[0]
        print(f"Deleting chat: {cid}")
        await client.delete_chat(cid)
else:
        print("No chat ID returned, cannot delete chat.")
```