### PR TITLE
Feature: Allow cookie_path to be set directly in client constructor

### DIFF
--- a/src/gemini_webapi/utils/get_access_token.py
+++ b/src/gemini_webapi/utils/get_access_token.py
@@ -1,6 +1,6 @@
+import asyncio
 import os
 import re
-import asyncio
 from asyncio import Task
 from pathlib import Path
 
@@ -32,7 +32,10 @@ async def send_request(
 
 
 async def get_access_token(
-    base_cookies: dict, proxy: str | None = None, verbose: bool = False
+    base_cookies: dict,
+    proxy: str | None = None,
+    cookie_path: Path | None = None,
+    verbose: bool = False,
 ) -> tuple[str, dict]:
     """
     Send a get request to gemini.google.com for each group of available cookies and return
@@ -49,6 +52,8 @@ async def get_access_token(
         Base cookies to be used in the request.
     proxy: `str`, optional
         Proxy URL.
+    cookie_path: `Path`, optional
+        Path to cache directory for cookies.
     verbose: `bool`, optional
         If `True`, will print more infomation in logs.
 
@@ -83,11 +88,14 @@ async def get_access_token(
         )
 
     # Cached cookies in local file
-    cache_dir = (
-        (GEMINI_COOKIE_PATH := os.getenv("GEMINI_COOKIE_PATH"))
-        and Path(GEMINI_COOKIE_PATH)
-        or (Path(__file__).parent / "temp")
-    )
+    if cookie_path is None:
+        cache_dir = (
+            (GEMINI_COOKIE_PATH := os.getenv("GEMINI_COOKIE_PATH"))
+            and Path(GEMINI_COOKIE_PATH)
+            or (Path(__file__).parent / "temp")
+        )
+    else:
+        cache_dir = cookie_path
     if "__Secure-1PSID" in base_cookies:
         filename = f".cached_1psidts_{base_cookies['__Secure-1PSID']}.txt"
         cache_file = cache_dir / filename

--- a/src/gemini_webapi/utils/rotate_1psidts.py
+++ b/src/gemini_webapi/utils/rotate_1psidts.py
@@ -8,7 +8,9 @@ from ..constants import Endpoint, Headers
 from ..exceptions import AuthError
 
 
-async def rotate_1psidts(cookies: dict, proxy: str | None = None) -> str:
+async def rotate_1psidts(
+    cookies: dict, proxy: str | None = None, cookie_path: Path | None = None
+) -> str:
     """
     Refresh the __Secure-1PSIDTS cookie and store the refreshed cookie value in cache file.
 
@@ -18,6 +20,8 @@ async def rotate_1psidts(cookies: dict, proxy: str | None = None) -> str:
         Cookies to be used in the request.
     proxy: `str`, optional
         Proxy URL.
+    cookie_path: `Path`, optional
+        Path to cache directory for cookies.
 
     Returns
     -------
@@ -31,12 +35,15 @@ async def rotate_1psidts(cookies: dict, proxy: str | None = None) -> str:
     `httpx.HTTPStatusError`
         If request failed with other status codes.
     """
+    if cookie_path is None:
+        path = (
+            (GEMINI_COOKIE_PATH := os.getenv("GEMINI_COOKIE_PATH"))
+            and Path(GEMINI_COOKIE_PATH)
+            or (Path(__file__).parent / "temp")
+        )
+    else:
+        path = cookie_path
 
-    path = (
-        (GEMINI_COOKIE_PATH := os.getenv("GEMINI_COOKIE_PATH"))
-        and Path(GEMINI_COOKIE_PATH)
-        or (Path(__file__).parent / "temp")
-    )
     path.mkdir(parents=True, exist_ok=True)
     filename = f".cached_1psidts_{cookies['__Secure-1PSID']}.txt"
     path = path / filename


### PR DESCRIPTION
Addresses [issue #189](https://github.com/HanaokaYuzu/Gemini-API/issues/189).

This pull request introduces a new, optional cookie_path parameter to the client constructor. This provides an explicit way to specify the cookies cache directory, which is useful when relying on environment variables is not feasible.

Precedence: The provided cookie_path parameter will take precedence over the GIMINI_COOKIE_PATH environment variable. If the parameter is not set (None), the existing logic (checking the environment variable) will be used.