### PR TITLE
fix: improve security by enabling SSL verification and restricting cookie file permissions

### DIFF
--- a/src/gemini_webapi/utils/get_access_token.py
+++ b/src/gemini_webapi/utils/get_access_token.py
@@ -24,7 +24,6 @@ async def send_request(
         headers=Headers.GEMINI.value,
         cookies=cookies,
         follow_redirects=True,
-        verify=False,
     ) as client:
         response = await client.get(Endpoint.INIT.value)
         response.raise_for_status()
@@ -65,7 +64,7 @@ async def get_access_token(
         If all requests failed.
     """
 
-    async with AsyncClient(proxy=proxy, follow_redirects=True, verify=False) as client:
+    async with AsyncClient(proxy=proxy, follow_redirects=True) as client:
         response = await client.get(Endpoint.GOOGLE.value)
 
     extra_cookies = {}

--- a/src/gemini_webapi/utils/rotate_1psidts.py
+++ b/src/gemini_webapi/utils/rotate_1psidts.py
@@ -56,4 +56,5 @@ async def rotate_1psidts(cookies: dict, proxy: str | None = None) -> str:
 
             if new_1psidts := response.cookies.get("__Secure-1PSIDTS"):
                 path.write_text(new_1psidts)
+                path.chmod(0o600)  # Restrict to owner read/write only
                 return new_1psidts


### PR DESCRIPTION

- Remove verify=False from AsyncClient calls to enable SSL certificate verification
- Add chmod 0o600 to cookie file to restrict access to owner only

# Security: SSL verification disabled and plaintext cookie storage

## Summary

During a security audit, I found two issues that could expose users to credential theft:

1. **SSL/TLS verification disabled** - `verify=False` in HTTP clients enables MITM attacks
2. **Cookie cache files world-readable** - No file permissions set on cached credentials

## Issue 1: SSL Verification Disabled (Critical)

**Location:** `src/gemini_webapi/utils/get_access_token.py`

**Current code:**
```python
# Line 22-27
async with AsyncClient(
    proxy=proxy,
    headers=Headers.GEMINI.value,
    cookies=cookies,
    follow_redirects=True,
    verify=False,  # <-- SSL verification disabled
) as client:

# Line 68
async with AsyncClient(proxy=proxy, follow_redirects=True, verify=False) as client:
```

**Impact:**
- Man-in-the-middle attackers can intercept traffic
- Authentication cookies (`__Secure-1PSID`, `__Secure-1PSIDTS`) can be stolen
- Particularly dangerous on public WiFi or untrusted networks

**Fix:**
Remove `verify=False` (httpx defaults to `verify=True`):
```python
async with AsyncClient(
    proxy=proxy,
    headers=Headers.GEMINI.value,
    cookies=cookies,
    follow_redirects=True,
) as client:
```

## Issue 2: Cookie Cache Permissions (Medium)

**Location:** `src/gemini_webapi/utils/rotate_1psidts.py`

**Current code:**
```python
# Line 57-58
if new_1psidts := response.cookies.get("__Secure-1PSIDTS"):
    path.write_text(new_1psidts)  # <-- Default permissions (typically 0644)
```

**Impact:**
- Cache files created with world-readable permissions
- Any user/process on the system can read the authentication token
- Risk on shared or multi-user systems

**Fix:**
Set restrictive permissions after writing:
```python
if new_1psidts := response.cookies.get("__Secure-1PSIDTS"):
    path.write_text(new_1psidts)
    path.chmod(0o600)  # Owner read/write only
```

## Environment

- gemini-webapi version: 1.17.3
- Python: 3.12
- OS: macOS (but issues affect all platforms)