### PR TITLE
feat: add ImageMode for image quality selection(Nano Banana Pro Support)

### DIFF
--- a/src/gemini_webapi/__init__.py
+++ b/src/gemini_webapi/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 from .client import GeminiClient, ChatSession
+from .constants import ImageMode, Model
 from .exceptions import *
 from .types import *
 from .utils import set_log_level, logger

--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -98,6 +98,18 @@ class Model(Enum):
         return custom_model
 
 
+class ImageMode(StrEnum):
+    """
+    Image generation quality mode.
+
+    PRO: High quality image generation using Nano Banana Pro model (default)
+    FAST: Faster generation with standard quality
+    """
+
+    PRO = "pro"
+    FAST = "fast"
+
+
 class ErrorCode(IntEnum):
     """
     Known error codes returned from server.


### PR DESCRIPTION
## Summary
Enable **Nano Banana Pro** mode for high-quality image generation via new `ImageMode` parameter.

This PR unlocks the Nano Banana Pro model (Google's higher quality image generation) which was previously not accessible through the API.

- `ImageMode.PRO` (default): High quality image generation using **Nano Banana Pro** model
- `ImageMode.FAST`: Standard quality, faster response (previous default behavior)

## How Nano Banana Pro is Triggered
Through reverse engineering the Gemini web interface, I discovered the following parameters:

1. **Header extension**: `x-goog-ext-525001261-jspb` with model signature `9d8ca3786ebdfbea`
2. **Payload parameters**: `idx17=[[1]]` (quality marker) + `idx49=14` (Pro flag)

These parameters activate the Nano Banana Pro model, resulting in significantly higher quality generated images.

## Usage
```python
from gemini_webapi import GeminiClient, ImageMode

# Pro mode (default) - high quality images
response = await client.generate_content("Generate a picture of a cat")

# Fast mode - faster generation
response = await client.generate_content(
    "Generate a picture of a cat",
    image_mode=ImageMode.FAST
)

# String input also supported
response = await client.generate_content(
    "Generate a picture of a cat",
    image_mode="fast"
)
```

## Changes
- `constants.py`: Add `ImageMode` enum
- `__init__.py`: Export `ImageMode`
- `client.py`: Implement `image_mode` parameter in `generate_content()`