### PR TITLE
fix: Update gemini-3.0-pro model header

### DIFF
--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -46,7 +46,7 @@ class Model(Enum):
     G_3_0_PRO = (
         "gemini-3.0-pro",
         {
-            "x-goog-ext-525001261-jspb": '[1,null,null,null,"e6fa609c3fa255c0",null,null,0,[4],null,null,2]'
+            "x-goog-ext-525001261-jspb": '[1,null,null,null,"e6fa609c3fa255c0",null,null,0,[4]]'
         },
         False,
     )


### PR DESCRIPTION
The current header for `Model.G_3_0_PRO` returns "Invalid response" errors.

- Updated header ID from `9d8ca3786ebdfbea` to `e6fa609c3fa255c0`

Related issues: #216 #211 