### PR TITLE
Fix the retry logic for unsaved conversations.

### DIFF
--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -874,7 +874,7 @@ class GeminiClient(GemMixin):
                     async for out in _process_parts(parsed_parts):
                         yield out
 
-                if not is_completed or not is_final_chunk or is_thinking or is_queueing:
+                if not (is_completed or is_final_chunk) or is_thinking or is_queueing:
                     logger.debug(
                         f"Stream interrupted (completed={is_completed}, final_chunk={is_final_chunk}, thinking={is_thinking}, queueing={is_queueing}). "
                         "Polling again..."


### PR DESCRIPTION
Fix the retry logic for unsaved conversations.

Debug logs:
```
2026-02-10 11:05:00.828 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 127.0.0.1:39324 - "GET /health HTTP/1.1" 200
2026-02-10 11:05:29.079 | DEBUG    | app.server.chat:_prepare_messages_for_model:487 - Applied 1 extra instructions for tool/structured output.
2026-02-10 11:05:29.079 | DEBUG    | app.server.chat:_find_reusable_session:722 - No reusable session found for 2 messages.
2026-02-10 11:05:29.082 | DEBUG    | app.server.chat:create_chat_completion:1403 - Client ID: tienphuoc, Input length: 1485, files count: 1
2026-02-10 11:05:29.083 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 172.25.0.1:54400 - "POST /v1/chat/completions HTTP/1.1" 200
2026-02-10 11:05:29.417 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/batchexecute?rpcids=ESY5D&_reqid=29132&rt=c&source-path=%2Fapp&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:05:30.972 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 127.0.0.1:55038 - "GET /health HTTP/1.1" 200
2026-02-10 11:05:31.031 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://content-push.googleapis.com/upload "HTTP/2 200 OK"
2026-02-10 11:05:31.172 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/batchexecute?rpcids=ESY5D&_reqid=129132&rt=c&source-path=%2Fapp&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:05:34.736 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate?_reqid=229132&rt=c&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:05:34.737 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:05:34.738 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:05:36.124 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:05:44.808 | DEBUG    | gemini_webapi.client:_generate:878 - Stream interrupted (completed=False, final_chunk=True, thinking=False, queueing=False). Polling again...
2026-02-10 11:05:53.647 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate?_reqid=329132&rt=c&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:05:53.648 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:05:53.649 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:05:55.060 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:05:55.064 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:06:01.124 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 127.0.0.1:37046 - "GET /health HTTP/1.1" 200
2026-02-10 11:06:03.504 | DEBUG    | gemini_webapi.client:_generate:878 - Stream interrupted (completed=False, final_chunk=True, thinking=False, queueing=False). Polling again...
2026-02-10 11:06:31.266 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 127.0.0.1:51864 - "GET /health HTTP/1.1" 200
2026-02-10 11:06:31.757 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate?_reqid=429132&rt=c&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:06:31.757 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:06:31.758 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:06:33.171 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:06:33.173 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:06:40.206 | DEBUG    | gemini_webapi.client:_generate:878 - Stream interrupted (completed=False, final_chunk=True, thinking=False, queueing=False). Polling again...
2026-02-10 11:06:59.364 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate?_reqid=529132&rt=c&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:06:59.365 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:06:59.367 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:07:00.847 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:07:00.851 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:07:01.426 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 127.0.0.1:51746 - "GET /health HTTP/1.1" 200
2026-02-10 11:07:09.215 | DEBUG    | gemini_webapi.client:_generate:878 - Stream interrupted (completed=False, final_chunk=True, thinking=False, queueing=False). Polling again...
2026-02-10 11:07:31.590 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 127.0.0.1:38184 - "GET /health HTTP/1.1" 200
2026-02-10 11:07:33.029 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate?_reqid=629132&rt=c&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:07:33.030 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:07:33.031 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:07:35.541 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:07:35.548 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:07:43.600 | DEBUG    | gemini_webapi.client:_generate:878 - Stream interrupted (completed=False, final_chunk=True, thinking=False, queueing=False). Polling again...
2026-02-10 11:08:01.748 | INFO     | uvicorn.protocols.http.h11_impl:send:480 - 127.0.0.1:37508 - "GET /health HTTP/1.1" 200
2026-02-10 11:08:12.373 | INFO     | httpx._client:_send_single_request:1740 - HTTP Request: POST https://gemini.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate?_reqid=729132&rt=c&bl=boq_assistant-bard-web-server_20260208.13_p0&f.sid=4900268403992740179 "HTTP/2 200 OK"
2026-02-10 11:08:12.374 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:08:12.375 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:08:15.637 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:08:15.639 | DEBUG    | gemini_webapi.client:_process_parts:659 - Model is active (thinking/analyzing)...
2026-02-10 11:08:29.419 | DEBUG    | gemini_webapi.client:_generate:878 - Stream interrupted (completed=False, final_chunk=True, thinking=False, queueing=False). Polling again...
2026-02-10 11:08:29.420 | ERROR    | app.server.chat:generate_stream:1044 - Error during OpenAI streaming: Stream interrupted or truncated.
```