### PR TITLE
fix: allow init without SNlM0e token

### DIFF
--- a/src/gemini_webapi/utils/get_access_token.py
+++ b/src/gemini_webapi/utils/get_access_token.py
@@ -189,15 +189,15 @@ async def get_access_token(
         try:
             response, request_cookies = await future
             snlm0e = re.search(r'"SNlM0e":\s*"(.*?)"', response.text)
-            if snlm0e:
-                cfb2h = re.search(r'"cfb2h":\s*"(.*?)"', response.text)
-                fdrfje = re.search(r'"FdrFJe":\s*"(.*?)"', response.text)
+            cfb2h = re.search(r'"cfb2h":\s*"(.*?)"', response.text)
+            fdrfje = re.search(r'"FdrFJe":\s*"(.*?)"', response.text)
+            if snlm0e or cfb2h or fdrfje:
                 if verbose:
                     logger.debug(
                         f"Init attempt ({i + 1}/{len(tasks)}) succeeded. Initializing client..."
                     )
                 return (
-                    snlm0e.group(1),
+                    snlm0e.group(1) if snlm0e else "",
                     cfb2h.group(1) if cfb2h else None,
                     fdrfje.group(1) if fdrfje else None,
                     request_cookies,


### PR DESCRIPTION
Google removed the SNlM0e token from gemini.google.com around Feb 2025, causing client initialization to fail even with valid cookies.

This change moves cfb2h/FdrFJe extraction outside the SNlM0e check and treats initialization as successful if any of the three tokens are found. When SNlM0e is absent, an empty string is returned for the access_token field, which still works correctly with the API.