### PR TITLE
fix: allow init without SNlM0e token

### DIFF
--- a/src/gemini_webapi/utils/get_access_token.py
+++ b/src/gemini_webapi/utils/get_access_token.py
@@ -197,7 +197,7 @@ async def get_access_token(
                         f"Init attempt ({i + 1}/{len(tasks)}) succeeded. Initializing client..."
                     )
                 return (
-                    snlm0e.group(1) if snlm0e else "",
+                    snlm0e.group(1) if snlm0e else None,
                     cfb2h.group(1) if cfb2h else None,
                     fdrfje.group(1) if fdrfje else None,
                     request_cookies,


### PR DESCRIPTION
## Problem

Google removed the `SNlM0e` token from the `gemini.google.com` page around February 2025. Since `get_access_token()` requires `SNlM0e` to be present, client initialization fails even with valid cookies:

The `cfb2h` and `FdrFJe` tokens are still present on the page and are sufficient for API calls to work.

## Changes

- Moved `cfb2h`/`FdrFJe` regex extraction outside the `if snlm0e:` block
- Changed success condition from `if snlm0e` to `if snlm0e or cfb2h or fdrfje`
- Return empty string `""` for `access_token` when `SNlM0e` is absent (the `"at"` parameter in API calls works fine with an empty value)