### PR TITLE
Fixes #270

### DIFF
--- a/src/gemini_webapi/utils/upload_file.py
+++ b/src/gemini_webapi/utils/upload_file.py
@@ -2,7 +2,16 @@ import inspect
 import io
 import random
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
+
+@runtime_checkable
+class FileLike(Protocol):
+    def read(self, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+    @property
+    def filename(self) -> str:
+        ...
 
 from httpx import AsyncClient
 from pydantic import ConfigDict, validate_call
@@ -20,7 +29,7 @@ def _generate_random_name(extension: str = ".txt") -> str:
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 async def upload_file(
-    file: Any,
+    file: str | Path | bytes | io.BytesIO | FileLike,
     proxy: str | None = None,
     filename: str | None = None,
 ) -> str:
@@ -83,13 +92,13 @@ async def upload_file(
         return response.text
 
 
-def parse_file_name(file: Any) -> str:
+def parse_file_name(file: str | Path | bytes | io.BytesIO | FileLike) -> str:
     """
     Parse the file name from the given path or generate a random one for in-memory data.
 
     Parameters
     ----------
-    file : `Any`
+    file : `str` | `Path` | `bytes` | `io.BytesIO` | `FileLike`
         Path to the file or file content.
 
     Returns
@@ -104,7 +113,9 @@ def parse_file_name(file: Any) -> str:
             raise ValueError(f"{file} is not a valid file.")
         return file.name
 
-    if hasattr(file, "filename") and isinstance(file.filename, str):
-        return file.filename
+    if hasattr(file, "filename"):
+        filename_attr = getattr(file, "filename")
+        if isinstance(filename_attr, str):
+            return filename_attr
 
     return _generate_random_name()


### PR DESCRIPTION
Fixes #270 

The Issue

upload_file() function explicitly type-checks for "str | Path | bytes | io.BytesIO". When users attempt to build wrappers using frameworks like FastAPI, passing an UploadFile object directly into client.generate_content(prompt, files=[file]) raises a ValueError: Unsupported file type, causing the stream to crash with a 500 Stream interrupted or truncated error.

The Fix

This PR implements duck-typing support using a structural FileLike Protocol.

upload_file.py now accepts any object that exposes a .read() method and a .filename property.
It natively supports await for asynchronous .read() implementations