### PR TITLE
fix: use writable temp dir for cookie cache

### DIFF
--- a/src/gemini_webapi/utils/rotate_1psidts.py
+++ b/src/gemini_webapi/utils/rotate_1psidts.py
@@ -1,6 +1,6 @@
 import os
-import time
 import tempfile
+import time
 from pathlib import Path
 
 import orjson as json


### PR DESCRIPTION
## Summary
- use a writable temp directory for cookie cache and refresh files
- honor `GEMINI_COOKIE_PATH` when it is set
- fall back to `/tmp/gemini_webapi` instead of the package directory

## Why
AWS Lambda layers are mounted read-only under `/opt`, so the previous default temp path could fail during cookie refresh and cache writes with `Read-only file system` errors.

## Testing
- `python3 -m py_compile src/gemini_webapi/utils/get_access_token.py src/gemini_webapi/utils/rotate_1psidts.py`