### PR TITLE
fix: retry on queueing state without CID (Gems support)

### DIFF
--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -1333,6 +1333,12 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
                                 )
                                 await asyncio.sleep(sleep_time)
                             break
+                        elif is_queueing and not has_generated_text:
+                            logger.debug(
+                                f"Stream suspended while queueing (no CID yet). Retrying request... (Request ID: {_reqid})"
+                            )
+                            await asyncio.sleep(sleep_time)
+                            continue
                         else:
                             logger.debug(
                                 f"Stream suspended (completed={is_completed}, final_chunk={is_final_chunk}, thinking={is_thinking}, queueing={is_queueing}). "


### PR DESCRIPTION
## Summary
  When using Gems (`generate_content(gem=...)`), the model may enter a queueing state
  where no conversation ID (CID) is available for recovery. Previously this raised
  `APIError` immediately. Now it retries the request, giving the model time to process.

## Testing
  - ✅ Predefined gems (brainstormer, coding-partner)
  - ✅ Custom user gems
  - ✅ No regression without gem parameter