### PR TITLE
fix: Deep Research report retrieval and cookie jar auth priority

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -361,18 +361,30 @@ async def cmd_research_get(args):
     cid = args.chat_id
     client, json_cookies = await _init_client(args)
     try:
-        latest = await client.fetch_latest_chat_response(cid)
-        if not latest:
+        # Read full chat history and find the longest model turn.
+        # Deep Research reports are stored in an immersive container
+        # at candidate_data[30][0][4], which _parse_candidate now extracts.
+        # The longest model turn is the research report.
+        history = await client.read_chat(cid, limit=20)
+        if not history or not history.turns:
             raise SystemExit(f"No response for chat {cid}. Research may still run.")
-        text = latest.text or ""
+
+        best_text = ""
+        for turn in history.turns:
+            if turn.role == "model" and turn.text and len(turn.text) > len(best_text):
+                best_text = turn.text
+
+        if not best_text:
+            raise SystemExit(f"No model response found in chat {cid}.")
+
         output_file = getattr(args, "output", None)
         if output_file:
             p = Path(output_file)
             p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text(text, encoding="utf-8")
+            p.write_text(best_text, encoding="utf-8")
             print(f"Saved research result to {output_file}")
         else:
-            print(text)
+            print(best_text)
         return 0
     finally:
         await _cleanup(client, args, json_cookies)

--- a/cli.py
+++ b/cli.py
@@ -319,7 +319,7 @@ async def cmd_research_send(args):
             prompt=args.prompt,
             model=args.model,
         )
-        await client.start_deep_research(plan=plan)
+        await client.start_deep_research(plan=plan, model=args.model)
         if not plan.cid:
             raise SystemExit("Deep research failed: no chat ID.")
 

--- a/cli.py
+++ b/cli.py
@@ -377,6 +377,13 @@ async def cmd_research_get(args):
         if not best_text:
             raise SystemExit(f"No model response found in chat {cid}.")
 
+        # Append source bibliography from the raw candidate data
+        sources = await _extract_dr_sources(cid, client)
+        if sources:
+            best_text += "\n\n---\n\n## Sources\n\n"
+            for i, url in enumerate(sources, 1):
+                best_text += f"[{i}] {url}\n"
+
         output_file = getattr(args, "output", None)
         if output_file:
             p = Path(output_file)
@@ -388,6 +395,72 @@ async def cmd_research_get(args):
         return 0
     finally:
         await _cleanup(client, args, json_cookies)
+
+
+async def _extract_dr_sources(cid, client):
+    """Extract source URLs from the Deep Research completion turn.
+
+    Sources are stored at candidate_data[30][0][17] (or [30][0][8]).
+    Returns a deduplicated list of URL strings.
+    """
+    import orjson as _orjson
+    from gemini_webapi.constants import GRPC as _GRPC
+    from gemini_webapi.types import RPCData as _RPCData
+    from gemini_webapi.utils import (
+        extract_json_from_response as _extract,
+        get_nested_value as _gnv,
+    )
+
+    try:
+        response = await client._batch_execute([
+            _RPCData(
+                rpcid=_GRPC.READ_CHAT,
+                payload=_orjson.dumps(
+                    [cid, 10, None, 1, [1], [4], None, 1]
+                ).decode("utf-8"),
+            ),
+        ])
+    except Exception:
+        return []
+
+    response_json = _extract(response.text)
+    for part in response_json:
+        part_body_str = _gnv(part, [2])
+        if not part_body_str:
+            continue
+        try:
+            part_body = _orjson.loads(part_body_str)
+        except Exception:
+            continue
+        turns_data = _gnv(part_body, [0])
+        if not turns_data:
+            continue
+        for conv_turn in turns_data:
+            candidates_list = _gnv(conv_turn, [3, 0])
+            if not candidates_list:
+                continue
+            for cd in candidates_list:
+                text = _gnv(cd, [1, 0], "")
+                if "immersive_entry_chip" not in text:
+                    continue
+                for path in ([30, 0, 17], [30, 0, 8]):
+                    sources_data = _gnv(cd, path, [])
+                    if not sources_data or not isinstance(sources_data, list):
+                        continue
+                    flat = json.dumps(sources_data, default=str)
+                    seen = set()
+                    urls = []
+                    for chunk in flat.split('"'):
+                        if (
+                            chunk.startswith("https://")
+                            and "gstatic.com" not in chunk
+                            and chunk not in seen
+                        ):
+                            seen.add(chunk)
+                            urls.append(chunk)
+                    if urls:
+                        return urls
+    return []
 
 
 async def cmd_list(args):

--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -1418,6 +1418,13 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
         if CARD_CONTENT_RE.match(text):
             text = get_nested_value(candidate_data, [22, 0]) or text
 
+        # Deep Research: the full report is stored at [30][0][4] when the
+        # main text contains an immersive_entry_chip URL (the acknowledgment).
+        if "immersive_entry_chip" in text:
+            dr_report = get_nested_value(candidate_data, [30, 0, 4])
+            if isinstance(dr_report, str) and dr_report:
+                text = dr_report
+
         # Cleanup googleusercontent artifacts
         text = ARTIFACTS_RE.sub("", text)
 

--- a/src/gemini_webapi/components/research_mixin.py
+++ b/src/gemini_webapi/components/research_mixin.py
@@ -250,6 +250,7 @@ class ResearchMixin:
         plan: DeepResearchPlan,
         chat: Optional["ChatSession"] = None,
         confirm_prompt: str | None = None,
+        model: Model | str | dict = Model.UNSPECIFIED,
     ) -> "ModelOutput":
         """
         Confirm and start a deep research plan.
@@ -262,6 +263,8 @@ class ResearchMixin:
             Existing session. Created from plan metadata if omitted.
         confirm_prompt: `str`, optional
             Override the default confirmation text.
+        model: `Model | str | dict`, optional
+            Model to use. Must match the model used in create_deep_research_plan.
 
         Returns
         -------
@@ -270,7 +273,7 @@ class ResearchMixin:
         """
 
         if chat is None:
-            chat = self.start_chat(metadata=list(plan.metadata), cid=plan.cid)
+            chat = self.start_chat(metadata=list(plan.metadata), cid=plan.cid, model=model)
         await self._deep_research_preflight()
         prompt = confirm_prompt or plan.confirm_prompt or "Start research"
         return await self._collect_research_output(chat, prompt)
@@ -376,6 +379,7 @@ class ResearchMixin:
         poll_interval: float = 10.0,
         timeout: float = 600.0,
         on_status: Callable[[DeepResearchStatus], None] | None = None,
+        model: Model | str | dict = Model.UNSPECIFIED,
     ) -> DeepResearchResult:
         """
         Run a full deep research cycle: plan → start → wait → result.
@@ -390,10 +394,12 @@ class ResearchMixin:
             Maximum seconds to wait. Default 600.
         on_status: `Callable`, optional
             Callback invoked with each `DeepResearchStatus`.
+        model: `Model | str | dict`, optional
+            Model to use for generation.
         """
 
-        plan = await self.create_deep_research_plan(prompt)
-        start_output = await self.start_deep_research(plan)
+        plan = await self.create_deep_research_plan(prompt, model=model)
+        start_output = await self.start_deep_research(plan, model=model)
         result = await self.wait_for_deep_research(
             plan,
             poll_interval=poll_interval,

--- a/src/gemini_webapi/utils/get_access_token.py
+++ b/src/gemini_webapi/utils/get_access_token.py
@@ -265,6 +265,7 @@ async def get_access_token(
             )
 
     current_attempt = 0
+    best_result = None
     for jar, group_name in cookie_jars_to_test:
         current_attempt += 1
         try:
@@ -275,11 +276,7 @@ async def get_access_token(
             language = re.search(r'"TuX5cc":\s*"(.*?)"', response.text)
             push_id = re.search(r'"qKIAYe":\s*"(.*?)"', response.text)
             if access_token or build_label or session_id or language or push_id:
-                if verbose:
-                    logger.debug(
-                        f"Init attempt ({current_attempt}) from {group_name} succeeded."
-                    )
-                return (
+                result = (
                     access_token.group(1) if access_token else None,
                     build_label.group(1) if build_label else None,
                     session_id.group(1) if session_id else None,
@@ -287,11 +284,33 @@ async def get_access_token(
                     push_id.group(1) if push_id else None,
                     client,
                 )
+                if access_token:
+                    if verbose:
+                        logger.debug(
+                            f"Init attempt ({current_attempt}) from {group_name} succeeded."
+                        )
+                    return result
+                elif best_result is None:
+                    # Partial auth (no SNlM0e) — keep trying other jars
+                    best_result = result
+                    if verbose:
+                        logger.debug(
+                            f"Init attempt ({current_attempt}) from {group_name} "
+                            "partial (no SNlM0e). Trying next jar..."
+                        )
         except Exception:
             if verbose:
                 logger.debug(
                     f"Init attempt ({current_attempt}) from {group_name} failed."
                 )
+
+    if best_result is not None:
+        if verbose:
+            logger.warning(
+                "No cookie jar returned SNlM0e access token. "
+                "Batch RPCs (read_chat, list_chats) will fail."
+            )
+        return best_result
 
     await client.close()
     raise AuthError(


### PR DESCRIPTION
## Summary

Three fixes that together make `research get` (and the Python API's `read_chat`) work correctly for Deep Research conversations.

### 1. Report extraction — `client.py`

Deep Research reports are stored at `candidate_data[30][0][4]` in an "immersive container" (23K+ chars), **not** at `[1][0]` which only contains the acknowledgment text plus an `immersive_entry_chip` URL that `ARTIFACTS_RE` strips out.

`_parse_candidate` now detects the `immersive_entry_chip` marker in the text and extracts the full report from `[30][0][4]`.

### 2. Cookie jar auth priority — `get_access_token.py`

When cached cookies return partial auth (`session_id`/`build_label` but no `SNlM0e`), the init loop returned early because the check is `if access_token or build_label or session_id`. This caused `access_token=None`, making all `_batch_execute` RPCs (`read_chat`, `list_chats`, `get_deep_research_status`) fail silently — the `"at"` field in POST data was `None`.

The loop now keeps trying remaining cookie jars until one returns `SNlM0e`, and only falls back to partial auth as a last resort. Related to #297.

### 3. CLI `research get` — `cli.py`

Changed from `fetch_latest_chat_response` (returns the most recent model turn, which is the acknowledgment) to reading the full chat history and returning the **longest** model turn — which is the research report.

## Test plan

- [x] Tested with completed Deep Research conversations on Google One AI Premium account
- [x] `research get c_<id>` returns full 23K+ char reports (was returning 92-char acknowledgment)
- [x] `read_chat` works after auth fix (was returning `None` for all chats)
- [x] `list_chats` returns results (was returning empty)
- [x] Single-turn `generate_content` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)