### PR TITLE
fix: don't retry on QueueingError (Veo/Lyria async queueing is not a transient error)

### DIFF
--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -34,6 +34,7 @@ from .exceptions import (
     AuthError,
     GeminiError,
     ModelInvalid,
+    QueueingError,
     TemporarilyBlocked,
     TimeoutError,
     UsageLimitExceeded,
@@ -1338,6 +1339,12 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
                                 f"Stream suspended (completed={is_completed}, final_chunk={is_final_chunk}, thinking={is_thinking}, queueing={is_queueing}). "
                                 f"No CID found to recover. (Request ID: {_reqid})"
                             )
+                            if is_queueing:
+                                raise QueueingError(
+                                    "Server is queueing the request for asynchronous processing "
+                                    "(e.g. Veo video generation). Poll via list_chats() + "
+                                    "read_chat() to retrieve the result."
+                                )
                             raise APIError(
                                 "The original request may have been silently aborted by Google."
                             )

--- a/src/gemini_webapi/exceptions.py
+++ b/src/gemini_webapi/exceptions.py
@@ -60,3 +60,15 @@ class TemporarilyBlocked(GeminiError):
     """
 
     pass
+
+
+class QueueingError(GeminiError):
+    """
+    Exception raised when the server is queueing a long-running generation
+    (e.g. Veo video). Unlike APIError, this should NOT trigger automatic
+    retry — the request was received and is being processed asynchronously.
+    Callers should poll via ``read_chat()`` or ``list_chats()`` to retrieve
+    the result once the server finishes rendering.
+    """
+
+    pass


### PR DESCRIPTION
## Problem

When `generate_content` encounters `Stream suspended (queueing=True)`, the server has accepted the request and is processing it asynchronously (e.g. Veo video rendering, Lyria music generation). The current code raises `APIError` at this point, which the `@running(retry=5)` decorator treats as a transient error and retries.

**Each retry sends a new request**, creating a new server-side job (new conversation) and burning an additional daily quota slot.

### Empirical evidence

Tested with Veo 3 video generation prompts:
- Within **45 seconds**, the decorator fired **4 retries**, creating **4 independent Veo conversations** visible in the Gemini web UI
- Each consumed a separate daily quota slot
- The backoff delays (5s/10s/15s/20s/25s) don't help because `Stream suspended` fires within ~12s of each attempt — faster than the first backoff

## Fix

Introduce `QueueingError(GeminiError)` — a new exception that inherits from `GeminiError` instead of `APIError`.

When `is_queueing=True` at the point of stream suspension:
- Raise `QueueingError` instead of `APIError`
- The `@running` decorator only retries `APIError`, so `QueueingError` bubbles up immediately with **zero retries**
- Callers can catch `QueueingError` and switch to a poll-based flow (`list_chats()` + `read_chat()`) to retrieve the result once the server finishes rendering

When `is_queueing=False` (transient connection issues, cookie drift, etc.):
- Still raises `APIError` as before — existing retry behaviour is preserved

## Changes

| File | Change |
|------|--------|
| `exceptions.py` | Add `QueueingError(GeminiError)` |
| `client.py` | Import `QueueingError`; raise it instead of `APIError` when `is_queueing=True` in the stream-suspended branch |

**No changes to `decorators.py`** — the fix works purely through the exception hierarchy.

## Backward compatibility

- Code that catches `APIError` will **not** catch `QueueingError` — this is intentional (the retry was harmful, not helpful)
- Code that catches `GeminiError` will catch `QueueingError` (since it's a subclass)
- Code that catches `Exception` is unaffected

## Usage example (after this fix)

```python
from gemini_webapi.exceptions import QueueingError

try:
    response = await client.generate_content("Generate a video of a cat")
except QueueingError:
    # Server accepted the request and is rendering asynchronously.
    # Poll list_chats() for the new conversation, then read_chat(cid)
    # to retrieve the generated video URL.
    new_chats = await client.list_chats()
    # ... poll and download
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)