### PR TITLE
feat: publish cli tool as an installable package entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ set_log_level("DEBUG")
 
 ## CLI Tool
 
-A standalone CLI (`cli.py`) is included for interacting with Gemini from the terminal. It supports single-turn questions, multi-turn chat, deep research, image download, and account diagnostics.
+A bundled CLI is included for interacting with Gemini from the terminal. It supports single-turn questions, multi-turn chat, deep research, image download, and account diagnostics. Once you install the package, you can use the `gemini-webapi-cli` command.
 
 ### Cookie Setup
 
@@ -718,31 +718,31 @@ You can also use a browser cookie extension export (array-of-objects format is s
 
 ```sh
 # Ask a single question (streams by default)
-python cli.py --cookies-json cookies.json ask "What is quantum computing?"
+gemini-webapi-cli --cookies-json cookies.json ask "What is quantum computing?"
 
 # Ask with image input
-python cli.py --cookies-json cookies.json ask --image photo.jpg "Describe this"
+gemini-webapi-cli --cookies-json cookies.json ask --image photo.jpg "Describe this"
 
 # Non-streaming mode
-python cli.py --cookies-json cookies.json ask --no-stream "Hello"
+gemini-webapi-cli --cookies-json cookies.json ask --no-stream "Hello"
 
 # Continue a conversation (chat ID from previous output)
-python cli.py --cookies-json cookies.json reply c_abc123 "Tell me more"
+gemini-webapi-cli --cookies-json cookies.json reply c_abc123 "Tell me more"
 
 # List your chat history
-python cli.py --cookies-json cookies.json list
+gemini-webapi-cli --cookies-json cookies.json list
 
 # Read a specific chat conversation
-python cli.py --cookies-json cookies.json read c_abc123
+gemini-webapi-cli --cookies-json cookies.json read c_abc123
 
 # List available models
-python cli.py --cookies-json cookies.json models
+gemini-webapi-cli --cookies-json cookies.json models
 
 # Download a generated image
-python cli.py --cookies-json cookies.json download "https://..." -o output.png
+gemini-webapi-cli --cookies-json cookies.json download "https://..." -o output.png
 
 # Account diagnostics (check feature availability)
-python cli.py --cookies-json cookies.json inspect
+gemini-webapi-cli --cookies-json cookies.json inspect
 ```
 
 ### Deep Research Workflow
@@ -751,16 +751,16 @@ The CLI supports Gemini's Deep Research feature — an autonomous research agent
 
 ```sh
 # 1. Submit a research task
-python cli.py --cookies-json cookies.json research send --prompt "AI chip competition 2025"
+gemini-webapi-cli --cookies-json cookies.json research send --prompt "AI chip competition 2025"
 
 # 2. Check progress (use the chat ID from step 1)
-python cli.py --cookies-json cookies.json research check c_abc123
+gemini-webapi-cli --cookies-json cookies.json research check c_abc123
 
 # 3. Fetch the full result
-python cli.py --cookies-json cookies.json research get c_abc123
+gemini-webapi-cli --cookies-json cookies.json research get c_abc123
 
 # 4. Save result to a file
-python cli.py --cookies-json cookies.json research get c_abc123 --output report.md
+gemini-webapi-cli --cookies-json cookies.json research get c_abc123 --output report.md
 ```
 
 ## References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ browser = ["browser-cookie3"]
 Repository = "https://github.com/HanaokaYuzu/Gemini-API"
 Issues = "https://github.com/HanaokaYuzu/Gemini-API/issues"
 
+[project.scripts]
+gemini-webapi-cli = "gemini_webapi.cli:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["gemini_webapi"]

--- a/src/gemini_webapi/cli.py
+++ b/src/gemini_webapi/cli.py
@@ -11,13 +11,10 @@ from email.utils import parsedate_to_datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
-ROOT = Path(__file__).resolve().parent
-sys.path.insert(0, str(ROOT / "src"))
-
-from gemini_webapi import GeminiClient, logger, set_log_level  # noqa: E402
-from gemini_webapi.constants import Model  # noqa: E402
-from gemini_webapi.exceptions import AuthError  # noqa: E402
-from gemini_webapi.types.image import GeneratedImage, WebImage  # noqa: E402
+from gemini_webapi import GeminiClient, logger, set_log_level
+from gemini_webapi.constants import Model
+from gemini_webapi.exceptions import AuthError
+from gemini_webapi.types.image import GeneratedImage, WebImage
 
 # ---------------------------------------------------------------------------
 # region - Cookie helpers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,12 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-# Ensure the repo root is on sys.path so `cli` can be imported directly
-ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "src"))
-
-from cli import build_parser  # noqa: E402
+from gemini_webapi.cli import build_parser
 
 
 @unittest.skipUnless(
@@ -48,21 +43,21 @@ class TestCLITool(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_cli_ask_stream(self):
-        from cli import cmd_ask
+        from gemini_webapi.cli import cmd_ask
 
         args = self._parse("ask", "Give me a inspiring idea for web development")
         result = await cmd_ask(args)
         self.assertEqual(result, 0)
 
     async def test_cli_list_chats(self):
-        from cli import cmd_list
+        from gemini_webapi.cli import cmd_list
 
         args = self._parse("list")
         result = await cmd_list(args)
         self.assertEqual(result, 0)
 
     async def test_cli_inspect(self):
-        from cli import cmd_inspect
+        from gemini_webapi.cli import cmd_inspect
 
         args = self._parse("inspect")
         result = await cmd_inspect(args)


### PR DESCRIPTION
This patch add a command line tool to run gemini-api via command line.

Fixes: #316 