### PR TITLE
feat: thinking model support and cookie handling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,27 @@ services:
 >
 > To avoid this, it's recommended to get cookies from a separate browser session and close it as soon as possible for best utilization (e.g. a fresh login in the browser's private mode). More details can be found [here](https://github.com/HanaokaYuzu/Gemini-API/issues/6).
 
+### Account Status & Model Availability
+
+During initialization, the library fetches your account status from Google's backend. You may see a warning like:
+
+```
+WARNING  Account status: UNAUTHENTICATED - Session is not authenticated or cookies have expired.
+```
+
+This is a **soft warning**, not a hard block. The `UNAUTHENTICATED` status (1016) causes Google to return a *reduced model list* from `list_models()` — typically 3-4 models instead of the full 9. However, **all models remain fully functional** when called by name:
+
+| `list_models()` shows | Also works (call by name) |
+|---|---|
+| `gemini-3-flash` | `gemini-3-flash-plus` |
+| `gemini-3-pro` | `gemini-3-pro-plus` |
+| `gemini-3-flash-thinking` | `gemini-3-flash-thinking-plus` |
+| | `gemini-3-pro-advanced` |
+| | `gemini-3-flash-advanced` |
+| | `gemini-3-flash-thinking-advanced` |
+
+The session status typically upgrades to `AVAILABLE` (1000) after a few successful requests or after `auto_refresh` rotates your cookies (enabled by default, every 600s). A hard block (e.g. `LOCATION_REJECTED`, `ACCOUNT_REJECTED`) would be logged at `WARNING` level and prevent model discovery entirely.
+
 ## Usage
 
 ### Initialization

--- a/README.md
+++ b/README.md
@@ -144,24 +144,40 @@ Use a browser extension like [EditThisCookie](https://www.editthiscookie.com/) o
 
 The simplest F12-only method — no extensions or extra dependencies required:
 
-1. Open <https://gemini.google.com> in Chrome → F12 → **Network** tab
-2. Refresh the page, then filter requests by `gemini.google.com`
-3. Right-click any request to `gemini.google.com` → **Copy** → **Copy as cURL (bash)**
-4. Run the extraction command below in your terminal:
+1. Save the extraction script below as `extract_cookies.py`:
 
-**Windows (PowerShell):**
+```python
+import subprocess, re, json, sys
 
-```powershell
-python -c "import subprocess,re,json; clip=subprocess.check_output(['powershell','-command','Get-Clipboard']).decode().strip(); m=re.search(r\"-b '([^']+)'\",clip) or re.search(r'-b \"([^\"]+)\"',clip); cookies=dict(p.split('=',1) for p in m.group(1).split('; ')); json.dump(cookies,open('cookies.json','w'),indent=2,ensure_ascii=False); print(f'Saved {len(cookies)} cookies to cookies.json')"
+# Read cURL command from clipboard
+if sys.platform == 'win32':
+    clip = subprocess.check_output(
+        ['powershell', '-command', 'Get-Clipboard']
+    ).decode('utf-8').strip()
+else:
+    import subprocess as sp
+    cmd = ['pbpaste'] if sys.platform == 'darwin' else ['xclip', '-selection', 'clipboard', '-o']
+    clip = sp.check_output(cmd).decode('utf-8').strip()
+
+# Extract cookie string from -b flag (or -H 'Cookie: ...')
+m = re.search(r"-b '([^']+)'", clip) or re.search(r'-b "([^"]+)"', clip)
+if not m:
+    m = re.search(r"-H 'Cookie:\s*([^']+)'", clip) or re.search(r'-H \"Cookie:\s*([^\"]+)\"', clip)
+if not m:
+    sys.exit('No Cookie header found in clipboard. Did you copy a gemini.google.com request?')
+
+cookies = dict(p.split('=', 1) for p in m.group(1).split('; '))
+with open('cookies.json', 'w', encoding='utf-8') as f:
+    json.dump(cookies, f, indent=2, ensure_ascii=False)
+print(f'Saved {len(cookies)} cookies to cookies.json')
+for k in sorted(cookies):
+    print(f'  {k}=PRESENT' if cookies[k] else f'  {k}=EMPTY')
 ```
 
-**macOS / Linux:**
-
-```bash
-pbpaste | python3 -c "import sys,re,json; clip=sys.stdin.read().strip(); m=re.search(r\"-b '([^']+)'\",clip) or re.search(r'-b \"([^\"]+)\"',clip); cookies=dict(p.split('=',1) for p in m.group(1).split('; ')); json.dump(cookies,open('cookies.json','w'),indent=2,ensure_ascii=False); print(f'Saved {len(cookies)} cookies')"
-```
-
-> On Linux, replace `pbpaste` with `xclip -selection clipboard -o` (X11) or `wl-paste` (Wayland).
+2. Open <https://gemini.google.com> in Chrome → F12 → **Network** tab
+3. Refresh the page, filter requests by `gemini.google.com`
+4. Right-click a request to `gemini.google.com` → **Copy** → **Copy as cURL (bash)**
+5. Run: `python extract_cookies.py`
 
 > [!NOTE]
 > Unlike HAR export (which strips cookies for privacy), **Copy as cURL** preserves the full cookie string via the `-b` flag. Make sure you copy a request to `gemini.google.com` — analytics/tracking requests won't contain auth cookies.

--- a/README.md
+++ b/README.md
@@ -98,13 +98,70 @@ pip install -U gemini_webapi[browser]
 
 ## Authentication
 
+> [!IMPORTANT]
+>
+> Google Gemini requires a **full set of authentication cookies** — not just `__Secure-1PSID` and `__Secure-1PSIDTS`. The backend validates your identity across a chain of session, API, and CSRF cookies. Missing any one of them will cause `401` or `AuthError`.
+
+### Required Cookies
+
+The following cookies (typically 19–22 entries for the `.google.com` domain) are needed. They are organized by purpose:
+
+| Category | Required Cookies | Purpose |
+|---|---|---|
+| Core session | `__Secure-1PSID`, `__Secure-1PSIDTS`, `__Secure-3PSID`, `__Secure-3PSIDTS`, `SID` | Primary authentication and session rotation |
+| API auth | `APISID`, `SAPISID`, `__Secure-1PAPISID`, `__Secure-3PAPISID`, `HSID`, `SSID` | API request signing |
+| CSRF | `SIDCC`, `__Secure-1PSIDCC`, `__Secure-3PSIDCC` | Cross-site request forgery tokens |
+| Gemini app | `COMPASS`, `NID` | Gemini-specific preferences and app state |
+
+> Analytics cookies (`_ga`, `_ga_*`, `_gcl_au`) are not needed and can be safely omitted.
+
+### Method 1: Export cookies from your browser (recommended)
+
+Use a browser extension like [EditThisCookie](https://www.editthiscookie.com/) or [Cookie-Editor](https://cookie-editor.com/) to export all cookies for `.google.com` domain. Save them as a JSON file in this format:
+
+```json
+{
+    "__Secure-1PSID": "...",
+    "__Secure-1PSIDTS": "...",
+    "__Secure-3PSID": "...",
+    "__Secure-3PSIDTS": "...",
+    "SID": "...",
+    "HSID": "...",
+    "SSID": "...",
+    "APISID": "...",
+    "SAPISID": "...",
+    "__Secure-1PAPISID": "...",
+    "__Secure-3PAPISID": "...",
+    "SIDCC": "...",
+    "__Secure-1PSIDCC": "...",
+    "__Secure-3PSIDCC": "...",
+    "COMPASS": "...",
+    "NID": "..."
+}
+```
+
+### Method 2: Use browser-cookie3 (automatic)
+
 > [!TIP]
 >
-> If `browser-cookie3` is installed, you can skip this step and go directly to the [usage](#usage) section. Just make sure you are logged in to <https://gemini.google.com> in your browser.
+> If `browser-cookie3` is installed (`pip install gemini_webapi[browser]`), you can skip manual cookie export entirely. The library will load cookies directly from your local browser. Just make sure you are logged in to <https://gemini.google.com> in your browser.
 
-- Go to <https://gemini.google.com> and log in with your Google account
-- Press F12 to open the web inspector, go to the `Network` tab, and refresh the page
-- Click any request and copy the cookie values of `__Secure-1PSID` and `__Secure-1PSIDTS`
+```python
+client = GeminiClient()  # cookies auto-loaded from browser
+await client.init()
+```
+
+### Method 3: Use the capture script (Puppeteer)
+
+This repository includes `capture_cookies_v2.js` — a Puppeteer script that captures the full `Cookie` header from actual browser HTTP requests to `google.com`. This is the most reliable method, as it captures exactly what the browser sends:
+
+```sh
+node capture_cookies_v2.js
+```
+
+Make a query in the opened browser window with a thinking model. The script will auto-save all captured cookies to `cookies.json`.
+
+---
 
 > [!NOTE]
 >
@@ -133,20 +190,19 @@ services:
 
 ### Initialization
 
-Import the required packages and initialize a client with your cookies from the previous step. After successful initialization, the API will automatically refresh `__Secure-1PSIDTS` in the background as long as the process is alive.
+Load your cookies from a JSON file and initialize the client. After successful initialization, the API will automatically refresh `__Secure-1PSIDTS` in the background as long as the process is alive.
 
 ```python
 import asyncio
+import json
 from gemini_webapi import GeminiClient
 
-# Replace "COOKIE VALUE HERE" with your actual cookie values.
-# Leave Secure_1PSIDTS empty if it's not available for your account.
-Secure_1PSID = "COOKIE VALUE HERE"
-Secure_1PSIDTS = "COOKIE VALUE HERE"
-
 async def main():
-    # If browser-cookie3 is installed, simply use `client = GeminiClient()`
-    client = GeminiClient(Secure_1PSID, Secure_1PSIDTS, proxy=None)
+    # Load full cookie set from a JSON file
+    with open("cookies.json", "r", encoding="utf-8") as f:
+        cookies = json.load(f)
+
+    client = GeminiClient(cookies=cookies, proxy=None)
     await client.init(timeout=30, auto_close=False, close_delay=300, auto_refresh=True)
 
 asyncio.run(main())
@@ -480,15 +536,23 @@ asyncio.run(main())
 
 ### Retrieve Model's Thought Process
 
-When using models with thinking capabilities, the model's thought process will be populated in `ModelOutput.thoughts`.
+When using models with thinking capabilities (models with "thinking" in their name), the model's reasoning process is available in `ModelOutput.thoughts` (non-streaming) or `ModelOutput.thoughts_delta` (streaming).
 
 ```python
 async def main():
+    # Non-streaming: access .thoughts on the result
     response = await client.generate_content(
-            "What's 1+1?", model="gemini-3-pro"
-        )
-    print(response.thoughts)
-    print(response.text)
+        "What's 1+1?", model="gemini-3-flash-thinking"
+    )
+    print(response.thoughts)  # The model's reasoning process
+    print(response.text)      # The final answer
+
+    # Streaming: access .thoughts_delta on each chunk
+    async for chunk in client.generate_content_stream(
+        "What's 2+3?", model="gemini-3-flash-thinking"
+    ):
+        if chunk.thoughts_delta:
+            print(chunk.thoughts_delta, end="", flush=True)
 
 asyncio.run(main())
 ```
@@ -689,13 +753,30 @@ A standalone CLI (`cli.py`) is included for interacting with Gemini from the ter
 
 ### Cookie Setup
 
-Export your cookies from [gemini.google.com](https://gemini.google.com) and save them as a JSON file. The CLI supports multiple formats:
+Export your cookies from [gemini.google.com](https://gemini.google.com) as a JSON key-value file. See [Authentication](#authentication) above for the full list of required cookies and export methods. The JSON file should look like:
 
 ```json
-{ "__Secure-1PSID": "value...", "__Secure-1PSIDTS": "value..." }
+{
+    "__Secure-1PSID": "...",
+    "__Secure-1PSIDTS": "...",
+    "__Secure-3PSID": "...",
+    "__Secure-3PSIDTS": "...",
+    "SID": "...",
+    "HSID": "...",
+    "SSID": "...",
+    "APISID": "...",
+    "SAPISID": "...",
+    "__Secure-1PAPISID": "...",
+    "__Secure-3PAPISID": "...",
+    "SIDCC": "...",
+    "__Secure-1PSIDCC": "...",
+    "__Secure-3PSIDCC": "...",
+    "COMPASS": "...",
+    "NID": "..."
+}
 ```
 
-You can also use a browser cookie extension export (array-of-objects format is supported).
+If you have `browser-cookie3` installed, the CLI will auto-detect cookies from your browser — no JSON file needed.
 
 > [!NOTE]
 >

--- a/README.md
+++ b/README.md
@@ -140,7 +140,33 @@ Use a browser extension like [EditThisCookie](https://www.editthiscookie.com/) o
 }
 ```
 
-### Method 2: Use browser-cookie3 (automatic)
+### Method 2: Copy as cURL from DevTools (no extension needed)
+
+The simplest F12-only method — no extensions or extra dependencies required:
+
+1. Open <https://gemini.google.com> in Chrome → F12 → **Network** tab
+2. Refresh the page, then filter requests by `gemini.google.com`
+3. Right-click any request to `gemini.google.com` → **Copy** → **Copy as cURL (bash)**
+4. Run the extraction command below in your terminal:
+
+**Windows (PowerShell):**
+
+```powershell
+python -c "import subprocess,re,json; clip=subprocess.check_output(['powershell','-command','Get-Clipboard']).decode().strip(); m=re.search(r\"-b '([^']+)'\",clip) or re.search(r'-b \"([^\"]+)\"',clip); cookies=dict(p.split('=',1) for p in m.group(1).split('; ')); json.dump(cookies,open('cookies.json','w'),indent=2,ensure_ascii=False); print(f'Saved {len(cookies)} cookies to cookies.json')"
+```
+
+**macOS / Linux:**
+
+```bash
+pbpaste | python3 -c "import sys,re,json; clip=sys.stdin.read().strip(); m=re.search(r\"-b '([^']+)'\",clip) or re.search(r'-b \"([^\"]+)\"',clip); cookies=dict(p.split('=',1) for p in m.group(1).split('; ')); json.dump(cookies,open('cookies.json','w'),indent=2,ensure_ascii=False); print(f'Saved {len(cookies)} cookies')"
+```
+
+> On Linux, replace `pbpaste` with `xclip -selection clipboard -o` (X11) or `wl-paste` (Wayland).
+
+> [!NOTE]
+> Unlike HAR export (which strips cookies for privacy), **Copy as cURL** preserves the full cookie string via the `-b` flag. Make sure you copy a request to `gemini.google.com` — analytics/tracking requests won't contain auth cookies.
+
+### Method 3: Use browser-cookie3 (automatic)
 
 > [!TIP]
 >
@@ -151,7 +177,7 @@ client = GeminiClient()  # cookies auto-loaded from browser
 await client.init()
 ```
 
-### Method 3: Use the capture script (Puppeteer)
+### Method 4: Use the capture script (Puppeteer)
 
 This repository includes `capture_cookies_v2.js` — a Puppeteer script that captures the full `Cookie` header from actual browser HTTP requests to `google.com`. This is the most reliable method, as it captures exactly what the browser sends:
 

--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -68,6 +68,21 @@ from .utils import (
 )
 
 
+def _is_thinking_model_param(model: Any) -> bool:
+    """Check if the model parameter represents a thinking model (supports str, Model, dict, AvailableModel)."""
+    if isinstance(model, str):
+        return "thinking" in model.lower()
+    if isinstance(model, Model):
+        return "thinking" in (model.model_name or "").lower()
+    if isinstance(model, dict):
+        return "thinking" in (model.get("model_name", "") or "").lower()
+    if hasattr(model, "model_name"):
+        return "thinking" in (getattr(model, "model_name", "") or "").lower()
+    if hasattr(model, "name"):
+        return "thinking" in (getattr(model, "name", "") or "").lower()
+    return False
+
+
 class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
     """
     Async requests client interface for gemini.google.com.
@@ -837,7 +852,7 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
 
         while True:
             try:
-                inner_req_list: list[Any] = [None] * 69
+                inner_req_list: list[Any] = [None] * 80
                 inner_req_list[0] = message_content
                 inner_req_list[1] = [self.language]
                 inner_req_list[2] = chat.metadata if chat else DEFAULT_METADATA
@@ -865,6 +880,7 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
                     inner_req_list[55] = [[1]]
                 inner_req_list[61] = []
                 inner_req_list[68] = 2
+                inner_req_list[79] = 5 if _is_thinking_model_param(model) else 3
 
                 uuid_val = str(uuid.uuid4()).upper()
 
@@ -1613,9 +1629,14 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
             if self.session_id:
                 params["f.sid"] = self.session_id
 
+            batch_uuid = str(uuid.uuid4()).upper()
             request_headers = {
                 **Headers.GEMINI.value,
                 **Headers.BATCH_EXEC.value,
+                "x-goog-ext-525001261-jspb": (
+                    f"[1,null,null,null,null,null,null,null,[4],null,null,"
+                    f"null,null,3,null,null,\"{batch_uuid}\"]"
+                ),
                 **Headers.SAME_DOMAIN.value,
             }
 

--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -141,6 +141,7 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
         secure_1psid: str | None = None,
         secure_1psidts: str | None = None,
         proxy: str | None = None,
+        cookies: dict | Cookies | None = None,
         **kwargs,
     ):
         super().__init__()
@@ -168,7 +169,20 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
         self._lock = asyncio.Lock()
         self.kwargs = kwargs
 
-        if secure_1psid:
+        if cookies:
+            if isinstance(cookies, Cookies):
+                for c in cookies.jar:
+                    if c.name and c.value and not c.is_expired():
+                        self._cookies.set(
+                            c.name, c.value,
+                            domain=c.domain or ".google.com",
+                            path=c.path or "/",
+                        )
+            else:
+                for k, v in cookies.items():
+                    if v:
+                        self._cookies.set(k, v, domain=".google.com", path="/")
+        elif secure_1psid:
             self._cookies.set("__Secure-1PSID", secure_1psid, domain=".google.com")
             if secure_1psidts:
                 self._cookies.set(
@@ -190,13 +204,26 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
         """
 
         if isinstance(value, Cookies):
-            self._cookies.update(value)
+            for c in value.jar:
+                if c.name and c.value and not c.is_expired():
+                    self._cookies.set(
+                        c.name, c.value,
+                        domain=c.domain or ".google.com",
+                        path=c.path or "/",
+                    )
         elif isinstance(value, dict):
             for k, v in value.items():
-                self._cookies.set(k, v, domain=".google.com")
+                if v:
+                    self._cookies.set(k, v, domain=".google.com", path="/")
 
         if self.client:
-            self.client.cookies.update(self._cookies)
+            for c in self._cookies.jar:
+                if c.name and c.value and not c.is_expired():
+                    self.client.cookies.set(
+                        c.name, c.value,
+                        domain=c.domain or ".google.com",
+                        path=c.path or "/",
+                    )
 
     async def init(
         self,

--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from enum import Enum, IntEnum, StrEnum
 
 import orjson as json
@@ -13,14 +14,34 @@ DEFAULT_METADATA = ["", "", "", None, None, None, None, None, None, ""]
 
 MODEL_HEADER_KEY = "x-goog-ext-525001261-jspb"
 
+# Model IDs for thinking-capable models (from web browser reverse engineering)
+_THINKING_MODEL_IDS = {"e051ce1aa80aa576", "5bf011840784117a"}
+
+
+def _is_thinking_model(model_id: str) -> bool:
+    """Check if the model ID represents a thinking model."""
+    return model_id in _THINKING_MODEL_IDS or "thinking" in model_id.lower()
+
 
 def build_model_header(model_id: str, capacity_tail: str | int) -> dict[str, str]:
     """
     Builds the complete HTTP header dictionary required for model selection.
+
+    Format reverse-engineered from the Gemini web browser client (17 elements).
+    Key differences from pre-2026 format:
+      - Position 7: null (was 0) — 0 suppresses thinking
+      - Position 13: thinking level (5=thinking, 3=normal)
+      - Position 16: session-stable random UUID
     """
 
+    thinking_level = 5 if _is_thinking_model(model_id) else 3
+    header_uuid = str(uuid.uuid4()).upper()
+
     return {
-        MODEL_HEADER_KEY: f'[1,null,null,null,"{model_id}",null,null,0,[4],null,null,{capacity_tail}]',
+        MODEL_HEADER_KEY: (
+            f'[1,null,null,null,"{model_id}",null,null,null,[4],null,null,'
+            f'{capacity_tail},null,{thinking_level},null,null,"{header_uuid}"]'
+        ),
         "x-goog-ext-73010989-jspb": "[0]",
         "x-goog-ext-73010990-jspb": "[0]",
     }
@@ -87,7 +108,7 @@ class Headers(Enum):
     }
     UPLOAD = {"X-Tenant-Id": "bard-storage"}
     BATCH_EXEC = {
-        "x-goog-ext-525001261-jspb": "[1,null,null,null,null,null,null,null,[4]]",
+        "x-goog-ext-525001261-jspb": "[1,null,null,null,null,null,null,null,[4],null,null,null,null,null,3,null,\"00000000-0000-0000-0000-000000000000\"]",
         "x-goog-ext-73010989-jspb": "[0]",
     }
 

--- a/src/gemini_webapi/utils/get_access_token.py
+++ b/src/gemini_webapi/utils/get_access_token.py
@@ -22,12 +22,18 @@ async def _send_request(
     Send http request with provided cookies using a shared session.
     """
 
-    client.cookies.clear()
+    # Set each cookie individually for correct domain/path preservation
     if isinstance(cookies, Cookies):
-        client.cookies.update(cookies)
+        for cookie in cookies.jar:
+            if cookie.name and cookie.value and not cookie.is_expired():
+                client.cookies.set(
+                    cookie.name, cookie.value,
+                    domain=cookie.domain, path=cookie.path,
+                )
     else:
         for k, v in cookies.items():
-            client.cookies.set(k, v, domain=".google.com")
+            if v:
+                client.cookies.set(k, v, domain=".google.com", path="/")
 
     response = await client.get(Endpoint.INIT, headers=Headers.GEMINI.value)
     if verbose:
@@ -75,17 +81,62 @@ async def get_access_token(
         impersonate="chrome", proxy=proxy, allow_redirects=True, verify=verify
     )
 
+    # Set base cookies BEFORE preflight so Google sees authenticated request
+    if isinstance(base_cookies, Cookies):
+        for cookie in base_cookies.jar:
+            if cookie.name and cookie.value and not cookie.is_expired():
+                client.cookies.set(
+                    cookie.name, cookie.value,
+                    domain=cookie.domain or ".google.com",
+                    path=cookie.path or "/",
+                )
+    else:
+        for name, value in base_cookies.items():
+            if value:
+                client.cookies.set(name, value, domain=".google.com", path="/")
+
     try:
         response = await client.get(Endpoint.GOOGLE)
         if verbose:
             logger.debug(
                 f"HTTP Request: GET {Endpoint.GOOGLE} [{response.status_code}]"
             )
-        preflight_cookies = Cookies(client.cookies)
     except Exception:
         await client.close()
         raise
 
+    # Direct init attempt: get the init page with all cookies already on client
+    try:
+        init_response = await client.get(Endpoint.INIT, headers=Headers.GEMINI.value)
+        if verbose:
+            logger.debug(
+                f"HTTP Request: GET {Endpoint.INIT} [{init_response.status_code}]"
+            )
+        init_response.raise_for_status()
+
+        access_token = re.search(r'"SNlM0e":\s*"(.*?)"', init_response.text)
+        if access_token:
+            build_label = re.search(r'"cfb2h":\s*"(.*?)"', init_response.text)
+            session_id = re.search(r'"FdrFJe":\s*"(.*?)"', init_response.text)
+            language = re.search(r'"TuX5cc":\s*"(.*?)"', init_response.text)
+            push_id = re.search(r'"qKIAYe":\s*"(.*?)"', init_response.text)
+            if verbose:
+                logger.debug("Init attempt from Direct succeeded.")
+            return (
+                access_token.group(1),
+                build_label.group(1) if build_label else None,
+                session_id.group(1) if session_id else None,
+                language.group(1) if language else None,
+                push_id.group(1) if push_id else None,
+                client,
+            )
+        elif verbose:
+            logger.debug("Direct init: access_token not found in init response.")
+    except Exception as e:
+        if verbose:
+            logger.debug(f"Direct init attempt failed: {type(e).__name__}: {e}")
+
+    preflight_cookies = Cookies(client.cookies)
     extra_cookies = Cookies()
     if response.status_code == 200:
         extra_cookies = preflight_cookies


### PR DESCRIPTION
@
## Summary

This PR adds thinking/reasoning model support to Gemini-API and fixes several cookie handling issues that prevented proper authentication. All changes are based on reverse-engineering the browser client HTTP traffic.

## Changes

### 1. 17-element model header with thinking_level and UUID (`constants.py`)
The browser model header (`x-goog-ext-525001261-jspb`) expanded from 11 to 17 elements. Key new fields:
- Position 7: `null` (was `0`) — `0` explicitly suppresses thinking output
- Position 13: thinking level (`5`=thinking, `3`=normal)
- Position 16: session-stable random UUID

Batch exec header also updated to match the 17-element format.

### 2. 80-position inner request with thinking_level (`client.py`)
The `f.req` inner request array expanded from 69 to 80 positions. Position 79 controls thinking mode:
- `5` = enable thinking (for thinking-capable models)
- `3` = normal (default)

Without this, the backend returns text-only even for thinking models.

### 3. Add `cookies` parameter and replace `Cookies.update()` (`client.py`)
- `GeminiClient.__init__` now accepts `cookies=dict|Cookies` directly
- All `Cookies.update()` calls replaced with per-cookie jar iteration + `.set()`, because `curl_cffi.Cookies.update()` can silently drop cookies across jars

### 4. Rewrite get_access_token auth flow (`get_access_token.py`)
- Per-cookie iteration in `_send_request` instead of `clear()`+`update()`
- Base cookies now set on session **before** preflight (not after), so Google sees an authenticated request
- Direct init fast path: immediately attempt `gemini.google.com/app` with all cookies; if `SNlM0e` is found, return without iterating cookie jars
- Fix logic bug where `access_token` not found erroneously called `access_token.group(1)`

## Testing
- Thinking models (`gemini-3-flash-thinking`) correctly output `reasoning_content` in streaming and non-streaming responses via OpenAI-compatible proxy
- Non-thinking models unaffected
- Temporary chat (no history) and normal chat (history saved) both work correctly
- Full cookie dict (20 cookies from browser export) loads correctly via new `cookies=` parameter

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
@