### PR TITLE
feat: add GenerationTool parameter to generate_content() for native Veo/Lyria routing

### DIFF
--- a/src/gemini_webapi/__init__.py
+++ b/src/gemini_webapi/__init__.py
@@ -4,3 +4,4 @@ from .client import GeminiClient, ChatSession
 from .exceptions import *
 from .types import *
 from .utils import set_log_level, logger
+from .constants import GenerationTool

--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -543,6 +543,7 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
         chat: Optional["ChatSession"] = None,
         temporary: bool = False,
         deep_research: bool = False,
+        tool: "GenerationTool | None" = None,
         **kwargs,
     ) -> ModelOutput:
         """
@@ -568,6 +569,10 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
             If set to `True`, the ongoing conversation will not show up in Gemini history.
         deep_research: `bool`, optional
             If set to `True`, will enable deep research mode and start creating a deep research plan.
+        tool: `GenerationTool`, optional
+            Route the request to a specialized generation backend.
+            Use `GenerationTool.VIDEO` for Veo video generation or `GenerationTool.MUSIC` for Lyria music generation.
+            When set, injects the appropriate routing values into the internal request payload.
         kwargs: `dict`, optional
             Additional arguments which will be passed to the post request.
             Refer to `curl_cffi.requests.AsyncSession.request` for more information.
@@ -859,6 +864,12 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
                     inner_req_list[TEMPORARY_CHAT_FLAG_INDEX] = 1
                 if deep_research:
                     inner_req_list[49] = 1
+                if tool is not None:
+                    from .constants import TOOL_LIST_MIN_LEN, TOOL_MODE_INDEX, TOOL_FLAG_INDEX, _TOOL_FLAG_VALUES
+                    while len(inner_req_list) < TOOL_LIST_MIN_LEN:
+                        inner_req_list.append(None)
+                    inner_req_list[TOOL_MODE_INDEX] = int(tool)
+                    inner_req_list[TOOL_FLAG_INDEX] = _TOOL_FLAG_VALUES.get(int(tool), 1)
                 inner_req_list[53] = 0
                 if deep_research:
                     inner_req_list[54] = [[[[[1]]]]]

--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -638,6 +638,7 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
                 temporary=temporary,
                 session_state=session_state,
                 deep_research=deep_research,
+                tool=tool,
                 **kwargs,
             ):
                 pass
@@ -775,6 +776,7 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
         temporary: bool = False,
         session_state: dict[str, Any] | None = None,
         deep_research: bool = False,
+        tool: "GenerationTool | None" = None,
         **kwargs,
     ) -> AsyncGenerator[ModelOutput, None]:
         """

--- a/src/gemini_webapi/constants.py
+++ b/src/gemini_webapi/constants.py
@@ -274,6 +274,28 @@ class AccountStatus(IntEnum):
             return cls.ACCOUNT_REJECTED
 
 
+class GenerationTool(IntEnum):
+    """
+    Tool routing values for inner_req_list[49] to trigger specialized generation modes.
+
+    VIDEO routes to Google Veo (video generation).
+    MUSIC routes to Google Lyria (music generation).
+    """
+
+    VIDEO = 11   # inner[49]=11, inner[79]=3 → Veo
+    MUSIC = 21   # inner[49]=21, inner[79]=1 → Lyria
+
+
+TOOL_MODE_INDEX = 49       # inner_req_list index for tool selection
+TOOL_FLAG_INDEX = 79       # inner_req_list secondary mode flag
+TOOL_LIST_MIN_LEN = 80     # must pad inner_req_list from 69 to 80 when using tool
+
+_TOOL_FLAG_VALUES: dict[int, int] = {
+    GenerationTool.VIDEO: 3,
+    GenerationTool.MUSIC: 1,
+}
+
+
 class ErrorCode(IntEnum):
     """
     Known error codes returned from server.


### PR DESCRIPTION
## Summary

- Adds a `tool: GenerationTool | None = None` parameter to `generate_content()` that injects Veo or Lyria routing into the `inner_req_list` payload without any monkey-patching.
- Adds `GenerationTool(IntEnum)` enum with `VIDEO = 11` (routes to Veo) and `MUSIC = 21` (routes to Lyria).
- Adds routing constants `TOOL_MODE_INDEX = 49`, `TOOL_FLAG_INDEX = 79`, `TOOL_LIST_MIN_LEN = 80` (pads inner_req_list from 69 to 80 elements when needed).
- Exports `GenerationTool` from the package `__init__.py`.

## Background / Motivation

The Gemini web UI exposes three tool buttons: **Create image**, **Create video** (Veo), and **Create music** (Lyria). The routing is controlled by two indices in `inner_req_list` (the inner protobuf-over-JSON array sent to `StreamGenerate`):

| Tool | `inner[49]` | `inner[79]` |
|------|------------|------------|
| Veo (video) | 11 | 3 |
| Lyria (music) | 21 | 1 |
| Deep research | 1 | — |

Without these values, `generate_content()` always routes to the text LLM — video/music prompts get a text acknowledgement and Veo/Lyria never queue. This change makes the routing a first-class API parameter instead of requiring callers to monkey-patch `httpx_client.stream`.

## Usage

```python
from gemini_webapi import GeminiClient, GenerationTool

client = GeminiClient(secure_1psid=psid, secure_1psidts=psidts)
await client.init()

# Video generation (routes to Veo)
response = await client.generate_content(
    "A cat playing piano, cinematic",
    tool=GenerationTool.VIDEO,
)

# Music generation (routes to Lyria)
response = await client.generate_content(
    "Upbeat jazz background music",
    tool=GenerationTool.MUSIC,
)
```

## Notes

- `deep_research=True` and `tool=GenerationTool.VIDEO/MUSIC` should not be combined (deep_research also sets `inner[49]=1`; `tool` wins since it runs after).
- The list is padded only when `tool` is set, preserving the existing 69-element default.
- Verified empirically: `inner[49]=11, inner[79]=3` causes the server to queue a Veo job and suspend the stream; the conversation is committed at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)