### PR TITLE
Discover Gemini Web extended thinking mode

### DIFF
--- a/src/gemini_webapi/client.py
+++ b/src/gemini_webapi/client.py
@@ -451,6 +451,34 @@ class GeminiClient(ChatMixin, GemMixin, ResearchMixin):
                             )
                             self._model_registry[model_id] = model
 
+                # The web model picker also returns modes separately from the
+                # primary model list.  In particular, "Thinking" (mode 5) is
+                # the Extended Thinking switch shown under Flash.  Older code
+                # ignored this block, so callers could not discover or select
+                # the capability even though its request header is known.
+                mode_models = {
+                    1: Model.BASIC_FLASH,
+                    3: Model.BASIC_PRO,
+                    5: Model.BASIC_THINKING,
+                }
+                for mode_data in get_nested_value(part_body, [24, 1], []):
+                    mode_info = get_nested_value(mode_data, [0], [])
+                    mode_code = get_nested_value(mode_info, [1])
+                    model = mode_models.get(mode_code)
+                    if model is None or model.model_id in self._model_registry:
+                        continue
+
+                    self._model_registry[model.model_id] = AvailableModel(
+                        model_id=model.model_id,
+                        model_name=model.model_name,
+                        display_name=get_nested_value(mode_info, [4], model.model_name),
+                        description=get_nested_value(mode_info, [5], ""),
+                        capacity=capacity,
+                        capacity_field=capacity_field,
+                        # The UI exposes availability at index 7 for a mode.
+                        is_available=bool(get_nested_value(mode_info, [7], False)),
+                    )
+
                 return
 
     async def _send_bard_settings(self) -> None:

--- a/tests/test_client_features.py
+++ b/tests/test_client_features.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import logging
+import os
 from pathlib import Path
 
 from gemini_webapi import GeminiClient, Gem, set_log_level, logger
@@ -170,7 +171,7 @@ class TestGeminiClient(unittest.IsolatedAsyncioTestCase):
     async def test_thinking_model(self):
         response = await self.geminiclient.generate_content(
             "1+1=?",
-            model=Model.BASIC_PRO,
+            model=Model.BASIC_THINKING,
         )
         logger.debug(response.thoughts)
         logger.debug(response.text)

--- a/tests/test_thinking_discovery.py
+++ b/tests/test_thinking_discovery.py
@@ -1,0 +1,20 @@
+from gemini_webapi.client import GeminiClient
+from gemini_webapi.constants import Model
+from gemini_webapi.types import AvailableModel
+
+
+def test_extended_thinking_has_a_stable_model_identity():
+    """The model used by the web UI's Extended Thinking mode is addressable."""
+    assert Model.BASIC_THINKING.model_name == "gemini-3-flash-thinking"
+    assert Model.BASIC_THINKING.model_id == "5bf011840784117a"
+
+
+def test_model_registry_can_represent_extended_thinking():
+    model = AvailableModel(
+        model_id=Model.BASIC_THINKING.model_id,
+        model_name=Model.BASIC_THINKING.model_name,
+        display_name="Thinking",
+        description="Solves complex problems",
+        capacity=1,
+    )
+    assert model.model_header == Model.BASIC_THINKING.model_header


### PR DESCRIPTION
## Summary
- discover the separate Extended Thinking mode returned by Gemini's web model-picker payload
- expose mode `5` as `gemini-3-flash-thinking` in the dynamic model registry
- correct the existing thinking test to request `BASIC_THINKING` rather than Pro
- add regression coverage for the Extended Thinking model header and registry representation

## Root cause
The user-status RPC returns the main model list at index `15` and a separate mode-picker list at `[24][1]`. The client only parsed the primary list, silently discarding the web UI's `Thinking` mode. Consequently, downstream clients could not discover the model selected by Gemini Web's Extended Thinking control.

## Verification
- `python -m pytest tests/test_thinking_discovery.py -q` -> `2 passed`
- Confirmed against a live Gemini Web RPC payload that the mode-picker contains `Thinking` as mode `5`.