### PR TITLE
Separate network-related failure groups to prevent valid cookies from becoming invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD033 MD041 -->
+
 <p align="center">
     <img src="https://raw.githubusercontent.com/HanaokaYuzu/Gemini-API/master/assets/banner.png" width="55%" alt="Gemini Banner" align="center">
 </p>
@@ -90,7 +92,7 @@ Install or update the package with pip.
 pip install -U gemini_webapi
 ```
 
-Optionally, the package offers a way to automatically import cookies from your local browser via optional dependency `browser-cookie3`. To enable this feature, install `gemini_webapi[browser]` instead. Supported platforms and browsers can be found [here](https://github.com/borisbabic/browser_cookie3?tab=readme-ov-file#contribute).
+Optionally, the package offers a way to automatically import cookies from your local browser via optional dependency `browser-cookie3`. To enable this feature, install `gemini_webapi[browser]` instead. Currently, only Firefox is supported. The latest information about supported browsers can be found in the [browser-cookie3](https://github.com/borisbabic/browser_cookie3) repository.
 
 ```sh
 pip install -U gemini_webapi[browser]
@@ -127,7 +129,13 @@ services:
 >
 > This feature may require you to log in to your Google account again in the browser. This is expected behavior and won't affect the API's functionality.
 >
-> To avoid this, it's recommended to get cookies from a separate browser session and close it as soon as possible for best utilization (e.g. a fresh login in the browser's private mode). More details can be found [here](https://github.com/HanaokaYuzu/Gemini-API/issues/6).
+> To avoid this, it's recommended to get cookies from a separate browser session and close it as soon as possible for best utilization (e.g. a fresh login in the browser's private mode). More details can be found [in issue #6](https://github.com/HanaokaYuzu/Gemini-API/issues/6).
+
+<!-- markdownlint-disable-line MD028 -->
+
+> [!TIP]
+>
+> If cookies expire frequently, use Firefox to extract cookies. Recent versions of Chromium-based browsers use "Device Bound Session Credentials", which improves security but causes cookies to remain valid for only a few hours and prevents them from being renewed.
 
 ## Usage
 
@@ -624,7 +632,7 @@ asyncio.run(main())
 
 > [!NOTE]
 >
-> For region availability, your Google account's **preferred language** only needs to be set to one of the three supported languages listed above. You can change your language settings [here](https://myaccount.google.com/language).
+> For region availability, your Google account's **preferred language** only needs to be set to one of the three supported languages listed above. You can change your language settings [in your Google account settings](https://myaccount.google.com/language).
 
 ### Check and Switch to Other Reply Candidates
 
@@ -658,7 +666,7 @@ Gemini's deep research feature is an autonomous research agent that browses the 
 
 Under the hood this is an ordinary chat conversation: Gemini answers the first turn with a **plan**, and a second turn **confirms** it and starts the research. The task then runs server-side, detached from the session, so polling for the report does not require holding the conversation open.
 
-The finished report is delivered as an **inline document**, not as reply text — the reply itself is only a short notice such as *"I've completed your research"*. `result.text` returns the report, and `result.document` exposes it with its id and title:
+The finished report is delivered as an **inline document**, not as reply text — the reply itself is only a short notice such as _"I've completed your research"_. `result.text` returns the report, and `result.document` exposes it with its id and title:
 
 ```python
 result = await client.deep_research("...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "curl-cffi~=0.16.0",
+  "curl-cffi~=0.16.2",
   "loguru~=0.7.3",
   "orjson~=3.11.9",
   "pydantic~=2.12.5",

--- a/src/gemini_webapi/utils/get_access_token.py
+++ b/src/gemini_webapi/utils/get_access_token.py
@@ -5,10 +5,26 @@ from typing import NamedTuple
 
 import orjson as json
 from curl_cffi import CurlFollow, CurlHttpVersion
+from curl_cffi.curl import CurlError
 from curl_cffi.requests import AsyncSession, BrowserTypeLiteral, Cookies, Response
+from curl_cffi.requests.exceptions import (
+    ConnectionError as CurlConnectionError,
+)
+from curl_cffi.requests.exceptions import (
+    HTTPError,
+)
+from curl_cffi.requests.exceptions import (
+    Timeout as CurlTimeout,
+)
 
 from gemini_webapi.constants import BROWSER_TYPE, Endpoint, Headers, format_http_version
-from gemini_webapi.exceptions import AuthError
+from gemini_webapi.exceptions import (
+    AuthError,
+    TemporarilyBlockedError,
+)
+from gemini_webapi.exceptions import (
+    TimeoutError as GeminiTimeoutError,
+)
 
 from .load_browser_cookies import HAS_BC3, load_browser_cookies
 from .logger import logger
@@ -249,7 +265,15 @@ async def get_access_token(
     Raises
     ------
     `gemini_webapi.AuthError`
-        If all requests failed.
+        If all candidate cookie groups failed authentication or yielded no valid init tokens.
+    `gemini_webapi.TimeoutError`
+        If a request timed out during initialization.
+    `gemini_webapi.TemporarilyBlockedError`
+        If the client's IP is rate-limited (HTTP 429).
+    `curl_cffi.requests.exceptions.HTTPError`
+        If Google Gemini returned an unexpected 5xx server error.
+    `curl_cffi.requests.exceptions.CurlError`
+        If a network or transport connection failure occurred.
 
     """
     client = AsyncSession(
@@ -380,9 +404,37 @@ async def get_access_token(
                         logger.debug(
                             f"Init attempt ({attempts}) from {group_name} returned no init values."
                         )
-                except Exception:
+                except HTTPError as e:
+                    status = e.response.status_code if e.response else None
+                    if status == 429:
+                        raise TemporarilyBlockedError(
+                            "Your IP address has been temporarily flagged or blocked by Google (HTTP 429). "
+                            "Please try using a proxy, a different network, or wait for a while before retrying."
+                        ) from e
+                    if status and status >= 500:
+                        if verbose:
+                            logger.warning(
+                                f"Init attempt ({attempts}) from {group_name} failed due to Google server error (HTTP {status})."
+                            )
+                        raise
                     if verbose:
-                        logger.debug(f"Init attempt ({attempts}) from {group_name} failed.")
+                        logger.debug(
+                            f"Init attempt ({attempts}) from {group_name} failed (HTTP {status})."
+                        )
+                except (CurlTimeout, TimeoutError) as e:
+                    if verbose:
+                        logger.warning(
+                            f"Init attempt ({attempts}) from {group_name} timed out: {e}"
+                        )
+                    raise GeminiTimeoutError(
+                        f"Request timed out while connecting to {Endpoint.INIT}: {e}"
+                    ) from e
+                except (CurlConnectionError, CurlError, OSError) as e:
+                    if verbose:
+                        logger.warning(
+                            f"Init attempt ({attempts}) from {group_name} failed due to network error: {e}"
+                        )
+                    raise
 
             return None
 
@@ -404,12 +456,21 @@ async def get_access_token(
             preflight_cookies = (
                 Cookies(client.cookies) if response.status_code == 200 else Cookies()
             )
-        except Exception:
+        except (CurlTimeout, TimeoutError) as e:
+            raise GeminiTimeoutError(
+                f"Request timed out while connecting to {Endpoint.GOOGLE}: {e}"
+            ) from e
+        except (CurlConnectionError, CurlError, OSError) as e:
+            if not isinstance(e, HTTPError):
+                raise
+            logger.warning(f"Preflight request to google.com failed: {e}")
+            preflight_cookies = Cookies()
+        except Exception as e:
             if not cookie_jars_to_test:
-                # Nothing else to fall back on, surface the underlying network error
+                # Nothing else to fall back on, surface the underlying error
                 raise
 
-            logger.warning("Preflight request to google.com failed.")
+            logger.warning(f"Preflight request to google.com failed: {e}")
             preflight_cookies = Cookies()
 
         if _jar_signature(preflight_cookies):


### PR DESCRIPTION
- This PR separates network-related failure groups to ensure valid cookies stay intact. It also verifies that cached cookies are never accidentally removed or unlinked due to network or transport errors.
- A minor update to the README to add a tip for session stability and a small markdown lint fix.
- Update curl-cffi to the latest version to get the latest fingerprints.